### PR TITLE
支持 mybatis 配置自动下划线转驼峰：mybatis.map-underscore-to-camelcase

### DIFF
--- a/docs/framework/fit/java/user-guide-book/07. 数据访问.md
+++ b/docs/framework/fit/java/user-guide-book/07. 数据访问.md
@@ -230,8 +230,13 @@ mybatis:
   mapper-locations: '**/*.xml'
 ```
 
-配置完成后，开发者可以正常开发`MyBatis`的`Mapper`文件进行数据库操作。
+配置完成后，开发者可以正常开发`MyBatis`的`Mapper`文件进行数据库操作。 
 
+FIT 支持 `MyBatis` 的下划线自动转驼峰格式配置, 默认为关闭状态。 在`application.yml`文件中追加如下配置，即可开启。
+``` yaml
+mybatis:
+  map-underscore-to-camelcase: true
+```
 ## 使用示例
 
 以下提供一个搭配使用`Druid`和`MyBatis`的示例。

--- a/docs/framework/fit/java/user-guide-book/07. 数据访问.md
+++ b/docs/framework/fit/java/user-guide-book/07. 数据访问.md
@@ -230,13 +230,15 @@ mybatis:
   mapper-locations: '**/*.xml'
 ```
 
-配置完成后，开发者可以正常开发`MyBatis`的`Mapper`文件进行数据库操作。 
+配置完成后，开发者可以正常开发`MyBatis`的`Mapper`文件进行数据库操作。
 
-FIT 支持 `MyBatis` 的下划线自动转驼峰格式配置, 默认为关闭状态。 在`application.yml`文件中追加如下配置，即可开启。
+FIT 支持 `MyBatis` 的下划线自动转驼峰格式配置, 默认为关闭状态。在`application.yml`文件中追加如下配置，即可开启。
+
 ``` yaml
 mybatis:
   map-underscore-to-camelcase: true
 ```
+
 ## 使用示例
 
 以下提供一个搭配使用`Druid`和`MyBatis`的示例。

--- a/framework/fit/java/integration/fit-mybatis/pom.xml
+++ b/framework/fit/java/integration/fit-mybatis/pom.xml
@@ -43,5 +43,28 @@
             <version>${mybatis.version}</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- Test-->
+        <dependency>
+            <groupId>org.fitframework</groupId>
+            <artifactId>fit-test-framework</artifactId>
+            <version>${fit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/framework/fit/java/integration/fit-mybatis/pom.xml
+++ b/framework/fit/java/integration/fit-mybatis/pom.xml
@@ -44,7 +44,7 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Test-->
+        <!-- Test -->
         <dependency>
             <groupId>org.fitframework</groupId>
             <artifactId>fit-test-framework</artifactId>

--- a/framework/fit/java/integration/fit-mybatis/src/main/java/modelengine/fit/integration/mybatis/MybatisBeanContainerInitializedObserver.java
+++ b/framework/fit/java/integration/fit-mybatis/src/main/java/modelengine/fit/integration/mybatis/MybatisBeanContainerInitializedObserver.java
@@ -38,6 +38,7 @@ import java.util.Properties;
 @Order(Order.NEARLY_HIGH)
 public class MybatisBeanContainerInitializedObserver implements BeanContainerInitializedObserver {
     private static final String BYTEBUDDY_CONFIG = "mybatis.use-bytebuddy";
+    private static final String UNDERSCORE_TO_CAMEL_CASE = "mybatis.map-underscore-to-camelcase";
 
     private final BeanContainer container;
 
@@ -63,6 +64,7 @@ public class MybatisBeanContainerInitializedObserver implements BeanContainerIni
         configuration.setEnvironment(new Environment(PluginKey.identify(plugin.metadata()),
                 new ManagedTransactionFactory(transactionManager),
                 new LazyLoadedDataSource(container)));
+        configuration.setMapUnderscoreToCamelCase(config.get(UNDERSCORE_TO_CAMEL_CASE, Boolean.class));
         container.factories(Interceptor.class)
                 .stream()
                 .map(BeanFactory::<Interceptor>get)

--- a/framework/fit/java/integration/fit-mybatis/src/main/java/modelengine/fit/integration/mybatis/MybatisBeanContainerInitializedObserver.java
+++ b/framework/fit/java/integration/fit-mybatis/src/main/java/modelengine/fit/integration/mybatis/MybatisBeanContainerInitializedObserver.java
@@ -6,8 +6,6 @@
 
 package modelengine.fit.integration.mybatis;
 
-import static modelengine.fitframework.inspection.Validation.notNull;
-
 import modelengine.fit.integration.mybatis.util.SqlSessionFactoryHelper;
 import modelengine.fitframework.annotation.Component;
 import modelengine.fitframework.annotation.Order;
@@ -18,7 +16,6 @@ import modelengine.fitframework.ioc.lifecycle.container.BeanContainerInitialized
 import modelengine.fitframework.plugin.Plugin;
 import modelengine.fitframework.plugin.PluginKey;
 import modelengine.fitframework.transaction.TransactionManager;
-
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.plugin.Interceptor;
 import org.apache.ibatis.session.Configuration;
@@ -27,6 +24,9 @@ import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 
 import java.util.Optional;
 import java.util.Properties;
+
+import static modelengine.fitframework.inspection.Validation.notNull;
+import static modelengine.fitframework.util.ObjectUtils.nullIf;
 
 /**
  * 为 {@link BeanContainerInitializedObserver} 提供用以整合 MyBatis 的实现。
@@ -64,7 +64,7 @@ public class MybatisBeanContainerInitializedObserver implements BeanContainerIni
         configuration.setEnvironment(new Environment(PluginKey.identify(plugin.metadata()),
                 new ManagedTransactionFactory(transactionManager),
                 new LazyLoadedDataSource(container)));
-        configuration.setMapUnderscoreToCamelCase(config.get(UNDERSCORE_TO_CAMEL_CASE, Boolean.class));
+        configuration.setMapUnderscoreToCamelCase(nullIf(config.get(UNDERSCORE_TO_CAMEL_CASE, Boolean.class), false));
         container.factories(Interceptor.class)
                 .stream()
                 .map(BeanFactory::<Interceptor>get)

--- a/framework/fit/java/integration/fit-mybatis/src/main/java/modelengine/fit/integration/mybatis/MybatisBeanContainerInitializedObserver.java
+++ b/framework/fit/java/integration/fit-mybatis/src/main/java/modelengine/fit/integration/mybatis/MybatisBeanContainerInitializedObserver.java
@@ -6,6 +6,9 @@
 
 package modelengine.fit.integration.mybatis;
 
+import static modelengine.fitframework.inspection.Validation.notNull;
+import static modelengine.fitframework.util.ObjectUtils.nullIf;
+
 import modelengine.fit.integration.mybatis.util.SqlSessionFactoryHelper;
 import modelengine.fitframework.annotation.Component;
 import modelengine.fitframework.annotation.Order;
@@ -16,6 +19,7 @@ import modelengine.fitframework.ioc.lifecycle.container.BeanContainerInitialized
 import modelengine.fitframework.plugin.Plugin;
 import modelengine.fitframework.plugin.PluginKey;
 import modelengine.fitframework.transaction.TransactionManager;
+
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.plugin.Interceptor;
 import org.apache.ibatis.session.Configuration;
@@ -24,9 +28,6 @@ import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 
 import java.util.Optional;
 import java.util.Properties;
-
-import static modelengine.fitframework.inspection.Validation.notNull;
-import static modelengine.fitframework.util.ObjectUtils.nullIf;
 
 /**
  * 为 {@link BeanContainerInitializedObserver} 提供用以整合 MyBatis 的实现。

--- a/framework/fit/java/integration/fit-mybatis/src/test/java/modelengine/fit/integration/mybatis/WordMapperTest.java
+++ b/framework/fit/java/integration/fit-mybatis/src/test/java/modelengine/fit/integration/mybatis/WordMapperTest.java
@@ -1,0 +1,40 @@
+package modelengine.fit.integration.mybatis;
+
+import modelengine.fit.integration.mybatis.mapper.WordMapper;
+import modelengine.fit.integration.mybatis.model.WordDo;
+import modelengine.fitframework.annotation.Fit;
+import modelengine.fitframework.conf.Config;
+import modelengine.fitframework.test.annotation.MybatisTest;
+import modelengine.fitframework.test.annotation.Sql;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 测试数据库层。
+ *
+ * @author 李金绪
+ * @since 2025-02-25
+ */
+@MybatisTest(classes = {WordMapper.class})
+@Sql(scripts = "sql/create/word.sql")
+@DisplayName("测试自动转换驼峰形式")
+public class WordMapperTest {
+    @Fit
+    private WordMapper mapper;
+    @Fit
+    private Config config;
+
+    @Test
+    @DisplayName("测试配置打开时,下划线正确转换至驼峰")
+    void shouldOkWhenMapUnderscoreToCamelcase() {
+        WordDo oriWord = this.mapper.get("hello");
+        assertThat(oriWord).isNull();
+
+        this.mapper.add(new WordDo("hello", "h"));
+
+        WordDo curWord = this.mapper.get("hello");
+        assertThat(curWord.getFirstLetter()).isEqualTo("h");
+    }
+}

--- a/framework/fit/java/integration/fit-mybatis/src/test/java/modelengine/fit/integration/mybatis/WordMapperTest.java
+++ b/framework/fit/java/integration/fit-mybatis/src/test/java/modelengine/fit/integration/mybatis/WordMapperTest.java
@@ -1,3 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) 2025 Huawei Technologies Co., Ltd. All rights reserved.
+ *  This file is a part of the ModelEngine Project.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 package modelengine.fit.integration.mybatis;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/framework/fit/java/integration/fit-mybatis/src/test/java/modelengine/fit/integration/mybatis/WordMapperTest.java
+++ b/framework/fit/java/integration/fit-mybatis/src/test/java/modelengine/fit/integration/mybatis/WordMapperTest.java
@@ -1,15 +1,16 @@
 package modelengine.fit.integration.mybatis;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import modelengine.fit.integration.mybatis.mapper.WordMapper;
 import modelengine.fit.integration.mybatis.model.WordDo;
 import modelengine.fitframework.annotation.Fit;
 import modelengine.fitframework.conf.Config;
 import modelengine.fitframework.test.annotation.MybatisTest;
 import modelengine.fitframework.test.annotation.Sql;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * 测试数据库层。

--- a/framework/fit/java/integration/fit-mybatis/src/test/java/modelengine/fit/integration/mybatis/mapper/WordMapper.java
+++ b/framework/fit/java/integration/fit-mybatis/src/test/java/modelengine/fit/integration/mybatis/mapper/WordMapper.java
@@ -1,3 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) 2025 Huawei Technologies Co., Ltd. All rights reserved.
+ *  This file is a part of the ModelEngine Project.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 package modelengine.fit.integration.mybatis.mapper;
 
 import modelengine.fit.integration.mybatis.model.WordDo;

--- a/framework/fit/java/integration/fit-mybatis/src/test/java/modelengine/fit/integration/mybatis/mapper/WordMapper.java
+++ b/framework/fit/java/integration/fit-mybatis/src/test/java/modelengine/fit/integration/mybatis/mapper/WordMapper.java
@@ -1,0 +1,26 @@
+package modelengine.fit.integration.mybatis.mapper;
+
+import modelengine.fit.integration.mybatis.model.WordDo;
+
+/**
+ * {@link WordDo} 的测试用数据库持久化层。
+ *
+ * @author 李金绪
+ * @since 2025-02-25
+ */
+public interface WordMapper {
+    /**
+     * 添加单词。
+     *
+     * @param word 表示单词的 {@link WordDo}。
+     */
+    void add(WordDo word);
+
+    /**
+     * 获取单词。
+     *
+     * @param name 表示单词名称的 {@link String}。
+     * @return 表示单词的 {@link WordDo}。
+     */
+    WordDo get(String name);
+}

--- a/framework/fit/java/integration/fit-mybatis/src/test/java/modelengine/fit/integration/mybatis/model/WordDo.java
+++ b/framework/fit/java/integration/fit-mybatis/src/test/java/modelengine/fit/integration/mybatis/model/WordDo.java
@@ -1,3 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) 2025 Huawei Technologies Co., Ltd. All rights reserved.
+ *  This file is a part of the ModelEngine Project.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 package modelengine.fit.integration.mybatis.model;
 
 /**

--- a/framework/fit/java/integration/fit-mybatis/src/test/java/modelengine/fit/integration/mybatis/model/WordDo.java
+++ b/framework/fit/java/integration/fit-mybatis/src/test/java/modelengine/fit/integration/mybatis/model/WordDo.java
@@ -1,0 +1,60 @@
+package modelengine.fit.integration.mybatis.model;
+
+/**
+ * 测试用单词实体类。
+ *
+ * @author 李金绪
+ * @since 2025-02-25
+ */
+public class WordDo {
+    private String name;
+    private String firstLetter;
+
+    /**
+     * 构造函数。
+     *
+     * @param name 表示单词名称的 {@link String}。
+     * @param firstLetter 表示单词首字母的 {@link String}。
+     */
+    public WordDo(String name, String firstLetter) {
+        this.name = name;
+        this.firstLetter = firstLetter;
+    }
+
+    /**
+     * 获取单词名称。
+     *
+     * @return 表示单词名称的 {@link String}。
+     */
+    public String getName() {
+        return this.name;
+    }
+
+    /**
+     * 设置单词名称。
+     *
+     * @param name 表示单词名称的 {@link String}。
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 获取单词首字母。
+     *
+     * @return 表示单词首字母的 {@link String}。
+     */
+    public String getFirstLetter() {
+        return this.firstLetter;
+    }
+
+    /**
+     * 设置单词首字母。
+     *
+     * @param firstLetter 表示单词首字母的 {@link String}。
+     */
+
+    public void setFirstLetter(String firstLetter) {
+        this.firstLetter = firstLetter;
+    }
+}

--- a/framework/fit/java/integration/fit-mybatis/src/test/resources/application.yml
+++ b/framework/fit/java/integration/fit-mybatis/src/test/resources/application.yml
@@ -1,0 +1,8 @@
+fit:
+  beans:
+    packages:
+      - 'modelengine.fit.integration.mybatis'
+
+mybatis:
+  mapper-locations: 'mapper/*.xml'
+  map-underscore-to-camelcase: true

--- a/framework/fit/java/integration/fit-mybatis/src/test/resources/mapper/WordMapper.xml
+++ b/framework/fit/java/integration/fit-mybatis/src/test/resources/mapper/WordMapper.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="modelengine.fit.integration.mybatis.mapper.WordMapper">
+    <insert id="add" parameterType="modelengine.fit.integration.mybatis.model.WordDo">
+        INSERT INTO word (name, first_letter)
+        VALUES (#{name}, #{firstLetter})
+    </insert>
+    <select id="get" resultType="modelengine.fit.integration.mybatis.model.WordDo">
+        select *
+        from word
+        where name = #{name}
+    </select>
+</mapper>

--- a/framework/fit/java/integration/fit-mybatis/src/test/resources/sql/create/word.sql
+++ b/framework/fit/java/integration/fit-mybatis/src/test/resources/sql/create/word.sql
@@ -1,0 +1,7 @@
+DROP TABLE IF EXISTS word;
+CREATE TABLE word
+(
+    "id" bigserial primary key,
+    "name" varchar(255),
+    "first_letter" varchar(255)
+);


### PR DESCRIPTION
提供配置项 map-underscore-to-camelcase，默认为 false

``` yaml
mybatis:
  mapper-locations: 'mapper/*.xml'
  map-underscore-to-camelcase: true
```

note: 查阅资料发现 mybatis 暂时只提供该配置，蛇形转化等配置未提供 
#1 