### PR TITLE
[fit] 修复校验泛型元素为空时的错误

### DIFF
--- a/framework/fit/java/fit-extension/fit-validation/src/main/java/modelengine/fitframework/validation/ValidationHandler.java
+++ b/framework/fit/java/fit-extension/fit-validation/src/main/java/modelengine/fitframework/validation/ValidationHandler.java
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (c) 2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *  Copyright (c) 2025 Huawei Technologies Co., Ltd. All rights reserved.
  *  This file is a part of the ModelEngine Project.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
@@ -16,6 +16,7 @@ import modelengine.fitframework.pattern.builder.BuilderFactory;
 import modelengine.fitframework.util.AnnotationUtils;
 import modelengine.fitframework.util.ArrayUtils;
 import modelengine.fitframework.util.CollectionUtils;
+import modelengine.fitframework.util.MapUtils;
 import modelengine.fitframework.util.ObjectUtils;
 import modelengine.fitframework.util.ReflectionUtils;
 import modelengine.fitframework.util.StringUtils;
@@ -167,6 +168,9 @@ public class ValidationHandler {
     private List<ValidationMetadata> handleCollection(Type[] actualTypeArgs, Collection<?> validationValueCollection,
             Method method, Class<?>[] validationGroups) {
         Validation.equals(actualTypeArgs.length, 1, "The collection must have exactly 1 parameterized type.");
+        if (CollectionUtils.isEmpty(validationValueCollection)) {
+            return Collections.emptyList();
+        }
         return validationValueCollection.stream()
                 .flatMap(element -> this.getValidationFields(actualTypeArgs[0], element, method, validationGroups)
                         .stream())
@@ -176,12 +180,17 @@ public class ValidationHandler {
     private List<ValidationMetadata> handleMap(Type[] actualTypeArgs, Map<?, ?> validationValueMap, Method method,
             Class<?>[] validationGroups) {
         Validation.equals(actualTypeArgs.length, 2, "The map must have exactly 2 parameterized types.");
+        if (MapUtils.isEmpty(validationValueMap)) {
+            return Collections.emptyList();
+        }
         return validationValueMap.entrySet()
                 .stream()
-                .flatMap(entry -> Stream.concat(
-                        this.getValidationFields(actualTypeArgs[0], entry.getKey(), method, validationGroups).stream(),
-                        this.getValidationFields(actualTypeArgs[1], entry.getValue(), method, validationGroups).stream()
-                ))
+                .flatMap(entry -> Stream.concat(this.getValidationFields(actualTypeArgs[0],
+                                entry.getKey(),
+                                method,
+                                validationGroups).stream(),
+                        this.getValidationFields(actualTypeArgs[1], entry.getValue(), method, validationGroups)
+                                .stream()))
                 .collect(Collectors.toList());
     }
 

--- a/framework/fit/java/fit-extension/fit-validation/src/test/java/modelengine/fitframework/validation/ValidationDataControllerTest.java
+++ b/framework/fit/java/fit-extension/fit-validation/src/test/java/modelengine/fitframework/validation/ValidationDataControllerTest.java
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (c) 2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *  Copyright (c) 2025 Huawei Technologies Co., Ltd. All rights reserved.
  *  This file is a part of the ModelEngine Project.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
 
 /**
  * {@link ValidationDataController} 的测试集。
@@ -99,6 +101,38 @@ public class ValidationDataControllerTest {
     @DisplayName("不合法 Product 对象校验")
     void shouldFailedWhenCreateInvalidProduct() {
         Product product = new Product("", 10499.0, -1, "computer");
+        MockRequestBuilder requestBuilder =
+                MockMvcRequestBuilders.post("/validation/product/default").jsonEntity(product).responseType(Void.class);
+        this.response = this.mockMvc.perform(requestBuilder);
+        assertThat(this.response.statusCode()).isEqualTo(500);
+    }
+
+    @Test
+    @DisplayName("合法 Product-List<Car> 对象校验: cars = null")
+    void shouldOkWhenCreateInvalidProductWithNullListCar() {
+        Product product = new Product("mac", 10499.0, 100, "computer", null);
+        MockRequestBuilder requestBuilder =
+                MockMvcRequestBuilders.post("/validation/product/default").jsonEntity(product).responseType(Void.class);
+        this.response = this.mockMvc.perform(requestBuilder);
+        assertThat(this.response.statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    @DisplayName("合法 Product-List<Car> 对象校验: cars.size() = 1")
+    void shouldOkWhenCreateInvalidProductWithOneListCar() {
+        Car validCar = new Car(1, 1, "brand", "model", 2000, 1999);
+        Product product = new Product("mac", 10499.0, 100, "computer", Collections.singletonList(validCar));
+        MockRequestBuilder requestBuilder =
+                MockMvcRequestBuilders.post("/validation/product/default").jsonEntity(product).responseType(Void.class);
+        this.response = this.mockMvc.perform(requestBuilder);
+        assertThat(this.response.statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    @DisplayName("不合法 Product-List<Car> 对象校验: cars.size() = 2")
+    void shouldFailedWhenCreateInvalidProductWithOneListCar() {
+        Car validCar = new Car(1, 1, "brand", "model", 2000, 1999);
+        Product product = new Product("mac", 10499.0, 100, "computer", Arrays.asList(validCar, validCar));
         MockRequestBuilder requestBuilder =
                 MockMvcRequestBuilders.post("/validation/product/default").jsonEntity(product).responseType(Void.class);
         this.response = this.mockMvc.perform(requestBuilder);

--- a/framework/fit/java/fit-extension/fit-validation/src/test/java/modelengine/fitframework/validation/annotation/One.java
+++ b/framework/fit/java/fit-extension/fit-validation/src/test/java/modelengine/fitframework/validation/annotation/One.java
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) 2025 Huawei Technologies Co., Ltd. All rights reserved.
+ *  This file is a part of the ModelEngine Project.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+package modelengine.fitframework.validation.annotation;
+
+import modelengine.fitframework.validation.Validated;
+import modelengine.fitframework.validation.constraints.Constraint;
+import modelengine.fitframework.validation.validator.OneValidator;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * 表示单集合元素的测试注解类。
+ *
+ * @author 李金绪
+ * @since 2025-03-17
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint({OneValidator.class})
+@Validated
+public @interface One {
+    String message() default "元素数必须是 1.";
+
+    Class<?>[] groups() default {};
+}

--- a/framework/fit/java/fit-extension/fit-validation/src/test/java/modelengine/fitframework/validation/data/Product.java
+++ b/framework/fit/java/fit-extension/fit-validation/src/test/java/modelengine/fitframework/validation/data/Product.java
@@ -1,13 +1,16 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (c) 2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *  Copyright (c) 2025 Huawei Technologies Co., Ltd. All rights reserved.
  *  This file is a part of the ModelEngine Project.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
 package modelengine.fitframework.validation.data;
 
+import modelengine.fitframework.validation.annotation.One;
 import modelengine.fitframework.validation.constraints.NotBlank;
 import modelengine.fitframework.validation.constraints.Positive;
+
+import java.util.List;
 
 /**
  * 表示产品的数据类。
@@ -28,9 +31,11 @@ public class Product {
     @NotBlank(message = "产品类别不能为空")
     private String category;
 
+    @One
+    private List<Car> cars;
+
     /**
      * Product 默认构造函数。
-     *
      */
     public Product() {}
 
@@ -39,5 +44,13 @@ public class Product {
         this.price = price;
         this.quantity = quantity;
         this.category = category;
+    }
+
+    public Product(String name, Double price, Integer quantity, String category, List<Car> cars) {
+        this.name = name;
+        this.price = price;
+        this.quantity = quantity;
+        this.category = category;
+        this.cars = cars;
     }
 }

--- a/framework/fit/java/fit-extension/fit-validation/src/test/java/modelengine/fitframework/validation/validator/OneValidator.java
+++ b/framework/fit/java/fit-extension/fit-validation/src/test/java/modelengine/fitframework/validation/validator/OneValidator.java
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) 2025 Huawei Technologies Co., Ltd. All rights reserved.
+ *  This file is a part of the ModelEngine Project.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+package modelengine.fitframework.validation.validator;
+
+import static modelengine.fitframework.util.ObjectUtils.cast;
+
+import modelengine.fitframework.validation.ConstraintValidator;
+import modelengine.fitframework.validation.annotation.One;
+
+import java.util.List;
+
+/**
+ * 表示单集合元素的测试校验类。
+ *
+ * @author 李金绪
+ * @since 2025-03-17
+ */
+public class OneValidator implements ConstraintValidator<One, Object> {
+    @Override
+    public boolean isValid(Object value) {
+        if (value == null) {
+            return true;
+        }
+        if (!(value instanceof List)) {
+            return false;
+        }
+        List<Object> valueList = cast(value);
+        return valueList.size() == 1;
+    }
+}


### PR DESCRIPTION
issue:
当嵌套校验中包含泛型元素，且泛型元素为 null 的时候，会出现 NPE
![image](https://github.com/user-attachments/assets/172486f7-0162-4d89-b125-4aa6e6784d47)
![image](https://github.com/user-attachments/assets/435dba77-c0f0-4e85-8c5c-910287844b9b)

pr：
修复错误，并提交单测验证