### PR TITLE
[elsa] 升级依赖axios和webpack至无漏洞的版本

### DIFF
--- a/framework/elsa/fit-elsa-react/package.json
+++ b/framework/elsa/fit-elsa-react/package.json
@@ -25,7 +25,7 @@
     "@fit-elsa/elsa-core": "file:../fit-elsa",
     "@tinymce/tinymce-react": "4.3.0",
     "antd": "4.24.13",
-    "axios": "1.7.4",
+    "axios": "1.8.2",
     "monaco-editor": "^0.34.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/framework/elsa/fit-elsa/package.json
+++ b/framework/elsa/fit-elsa/package.json
@@ -42,7 +42,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "jsdom": "^21.1.0",
     "video.js": "^8.9.0",
-    "webpack": "5.89.0",
+    "webpack": "5.94.0",
     "webpack-cli": "5.1.4"
   }
 }


### PR DESCRIPTION
[elsa] 升级axios从1.7.4至1.8.2，webpack从5.89.0至5.94.0，解决原有版本的漏洞问题