### PR TITLE
[elsa] 解决使用了JadeInputTree组件在下拉框选项时，字体会在加粗和正常font-weight间来回切换的问题

### DIFF
--- a/framework/elsa/fit-elsa-react/src/components/common/JadeInputTree.jsx
+++ b/framework/elsa/fit-elsa-react/src/components/common/JadeInputTree.jsx
@@ -173,13 +173,13 @@ export const JadeInputTree = (
           initialValue={openRadioId}
         >
           <Radio.Group value={openRadioId ?? undefined} onChange={handleRadioChange}>
-            <Tree defaultExpandAll={defaultExpandAll} blockNode className='jade-ant-tree' showLine>
+            <Tree selectable={false} defaultExpandAll={defaultExpandAll} blockNode className='jade-ant-tree' showLine>
               {renderTreeNodes(treeData)}
             </Tree>
           </Radio.Group>
         </Form.Item>
       ) : (
-        <Tree defaultExpandAll={defaultExpandAll} blockNode className='jade-ant-tree' showLine>
+        <Tree selectable={false} defaultExpandAll={defaultExpandAll} blockNode className='jade-ant-tree' showLine>
           {renderTreeNodes(treeData)}
         </Tree>
       )}


### PR DESCRIPTION
[elsa] JadeInputTree中Tree组件不是用于选择的，可以直接设置selectable为false，避免在下拉框选项时，字体会在加粗和正常font-weight间来回切换的问题