### PR TITLE
[elsa] 注释节点强制列表样式

### DIFF
--- a/framework/elsa/fit-elsa-react/src/components/note/editor.css
+++ b/framework/elsa/fit-elsa-react/src/components/note/editor.css
@@ -3,6 +3,24 @@ body {
     line-height: 1.4;
 }
 
+/* ============ 新增：强制列表样式 ============ */
+ol, ul {
+    display: block !important;
+    margin-block-start: 1em !important;
+    margin-block-end: 1em !important;
+    padding-inline-start: 40px !important;
+    unicode-bidi: isolate !important;
+}
+
+ol {
+    list-style-type: decimal !important;
+}
+
+ul {
+    list-style-type: disc !important;
+}
+/* ========================================== */
+
 table {
     border-collapse: collapse
 }

--- a/framework/elsa/fit-elsa-react/src/components/note/editor.css
+++ b/framework/elsa/fit-elsa-react/src/components/note/editor.css
@@ -3,7 +3,6 @@ body {
     line-height: 1.4;
 }
 
-/* ============ 新增：强制列表样式 ============ */
 ol, ul {
     display: block !important;
     margin-block-start: 1em !important;
@@ -19,7 +18,6 @@ ol {
 ul {
     list-style-type: disc !important;
 }
-/* ========================================== */
 
 table {
     border-collapse: collapse


### PR DESCRIPTION
[elsa] 注释节点强制列表样式，解决部署大包时样式被覆盖导致无法显示列表样式的问题