### PR TITLE
[elsa] 修复页面打开应用时持续转圈无法操作的问题

### DIFF
--- a/framework/elsa/fit-elsa-react/src/components/base/jadeNodeDrawer.jsx
+++ b/framework/elsa/fit-elsa-react/src/components/base/jadeNodeDrawer.jsx
@@ -262,7 +262,7 @@ export const jadeNodeDrawer = (shape, div, x, y) => {
      * @override
      */
     self.drawDynamic = (context, x, y) => {
-        self.marquees.forEach(wd => {
+        (self.marquees || []).forEach(wd => {
             if (wd.loaded) {
                 wd.draw(context, x, y, shape)
             } else {


### PR DESCRIPTION
[elsa] 修复保存运行中节点的脏数据后，重新打开应用时，节点尚未渲染时，drawAnimation调用导致的空指针问题