### PR TITLE
[python] 升级 python 依赖三方包的版本

### DIFF
--- a/framework/fit/python/requirements.txt
+++ b/framework/fit/python/requirements.txt
@@ -1,4 +1,4 @@
 numpy==1.25.2
 PyYAML==6.0.1
-requests==2.31.0
-tornado==6.3.2
+requests==2.32.0
+tornado==6.4.2


### PR DESCRIPTION
python 当前依赖的三方包存在安全问题，需要升级 requests 与 tornado 这两个三方包的版本解决安全问题