### PR TITLE
[elsa] 交互逻辑修改

### DIFF
--- a/framework/elsa/fit-elsa-react/src/components/DefaultRoot.jsx
+++ b/framework/elsa/fit-elsa-react/src/components/DefaultRoot.jsx
@@ -161,7 +161,7 @@ export const DefaultRoot = forwardRef(function (
               <div className="sticky-header">
                 {shape.drawer.getHeaderComponent(data, shapeStatus)}
                 <div className="jade-form-drawer-close" onClick={() => {
-                  shape.page.onConfigShape = undefined;
+                  shape.unSelect();
                   setOpen(false);
                 }}>
                   <CloseOutlined style={{fontSize: '12px'}}/>

--- a/framework/elsa/fit-elsa-react/src/components/base/jadeNode.jsx
+++ b/framework/elsa/fit-elsa-react/src/components/base/jadeNode.jsx
@@ -505,5 +505,16 @@ export const jadeNode = (id, x, y, width, height, parent, drawer) => {
     }
   };
 
+  /**
+   * @override
+   */
+  const unSelect = self.unSelect;
+  self.unSelect = () => {
+    unSelect.apply(self, []);
+    if (self.page.onConfigShape === self.id) {
+      self.page.onConfigShape = undefined;
+    }
+  };
+
   return self;
 };


### PR DESCRIPTION
[elsa] 交互逻辑修改

1. 编排时单击空白处自动关闭详情窗口
2. 点击关闭详情窗口时，对应shape去除选中状态

