### PR TITLE
[elsa] 序列化保存改同步

### DIFF
--- a/framework/elsa/fit-elsa/core/atom.js
+++ b/framework/elsa/fit-elsa/core/atom.js
@@ -46,7 +46,7 @@ class Atom {
     constructor(detections = []) {
         let defaultDetections = [];
         defaultDetections.push({
-            props: new Set(["type"]), react: async function (property, value, preValue, target) {
+            props: new Set(["type"]), react: function (property, value, preValue, target) {
                 let parentChain = target.typeChain;
                 target.typeChain = {
                     parent: parentChain, type: value
@@ -156,7 +156,7 @@ class Atom {
 
         proxy.addDetection = (props, react) => {
             detections.push({
-                props: new Set(props), react: async function (property, value, preValue) {
+                props: new Set(props), react: function (property, value, preValue) {
                     if (proxy.page === undefined || proxy.page.disableReact) {
                         return;
                     }


### PR DESCRIPTION
序列化保存时改为同步调用，避免异步调用导致可能的错误的状态保存