### PR TITLE
[elsa] 指定ol和ul对应样式的适配范围

### DIFF
--- a/framework/elsa/fit-elsa-react/src/components/note/TextEditor.jsx
+++ b/framework/elsa/fit-elsa-react/src/components/note/TextEditor.jsx
@@ -16,7 +16,6 @@ import {useShapeContext} from '@/components/DefaultRoot.jsx';
 import {EditorToolbar} from '@/components/note/EditorToolBar.jsx';
 import PropTypes from 'prop-types';
 import {TOOL_BAR_SIZE} from '@/components/note/const.js';
-import {useTranslation} from 'react-i18next';
 import {ResizeButton} from '@/components/note/ResizeButton.jsx';
 import {EVENT_TYPE, isPointInRect} from '@fit-elsa/elsa-core';
 
@@ -33,7 +32,6 @@ import {EVENT_TYPE, isPointInRect} from '@fit-elsa/elsa-core';
  */
 const _TextEditor = ({text, style, dispatch, isFocused, isInDragging}) => {
   const shape = useShapeContext();
-  const {t} = useTranslation();
   const shapeDiv = shape.drawer.parent;
   const [isEditing, setIsEditing] = useState(false); // 控制编辑状态
   const editorRef = useRef(null); // 创建一个ref

--- a/framework/elsa/fit-elsa-react/src/components/note/editor.css
+++ b/framework/elsa/fit-elsa-react/src/components/note/editor.css
@@ -3,7 +3,8 @@ body {
     line-height: 1.4;
 }
 
-ol, ul {
+.mce-content-body ol,
+.mce-content-body ul {
     display: block !important;
     margin-block-start: 1em !important;
     margin-block-end: 1em !important;
@@ -11,11 +12,11 @@ ol, ul {
     unicode-bidi: isolate !important;
 }
 
-ol {
+.mce-content-body ol {
     list-style-type: decimal !important;
 }
 
-ul {
+.mce-content-body ul {
     list-style-type: disc !important;
 }
 


### PR DESCRIPTION
[elsa] 指定ol和ul对应样式的适配范围，限定用于mce-content-body这个className下