### PR TITLE
[elsa] 修改注释节点列表中li标签的样式

### DIFF
--- a/framework/elsa/fit-elsa-react/src/components/note/editor.css
+++ b/framework/elsa/fit-elsa-react/src/components/note/editor.css
@@ -12,11 +12,11 @@ body {
     unicode-bidi: isolate !important;
 }
 
-.mce-content-body ol {
+.mce-content-body ol li {
     list-style-type: decimal !important;
 }
 
-.mce-content-body ul {
+.mce-content-body ul li {
     list-style-type: disc !important;
 }
 


### PR DESCRIPTION
[elsa] 注释节点对于有序列表和无序列表中的li标签也要强制指定list-style-type的css，避免三合一部署时被其他样式覆盖