### PR TITLE
[fit]修正文档中编译输出目录描述不一致的问题

### DIFF
--- a/docs/framework/fit/java/articles/FIT框架：重新定义模块隔离与部署自由，让Swagger从生产环境“优雅消失”.md
+++ b/docs/framework/fit/java/articles/FIT框架：重新定义模块隔离与部署自由，让Swagger从生产环境“优雅消失”.md
@@ -108,7 +108,7 @@ FIT 框架默认配置`Swagger`功能插件，基于上面的操作步骤，访�
 
 若不希望部署`Swagger`插件，只需要在 FIT 内置插件目录中将`Swagger`插件移除：
 
-首先结束`fit`进程，打开`framework/fit/java/target/plugins`，该目录存放了编译 FIT 框架后生成的所有内置插件，删除插件`fit-http-openapi3-swagger-3.5.0-SNAPSHOT.jar`，重新启动 FIT 框架，此时环境中并没有部署`Swagger`插件，访问 `http://localhost:8080/openapi.html` 将得到 404 响应：
+首先结束`fit`进程，打开`build/plugins`，该目录存放了编译 FIT 框架后生成的所有内置插件，删除插件`fit-http-openapi3-swagger-3.5.0-SNAPSHOT.jar`，重新启动 FIT 框架，此时环境中并没有部署`Swagger`插件，访问 `http://localhost:8080/openapi.html` 将得到 404 响应：
 
 ``` json
 {
@@ -128,7 +128,7 @@ FIT 框架默认配置`Swagger`功能插件，基于上面的操作步骤，访�
 
 以`Swagger`插件为例，将`framework/fit/java/fit-builtin/plugins/fit-http-openapi3-swagger/target/fit-http-openapi3-swagger-3.5.0-SNAPSHOT.jar`复制到正在运行的`fit`进程的用户插件目录中，即可立刻实现`Swagger`功能，而在使用结束后，可以随时卸载，无需重启进程。
 
-> 注意，位于`framework/fit/java/target/plugins`下的插件属于 FIT 启动的内置插件，包含了 FIT 框架提供的一系列功能，并不支持运行时热插拔，用户需要在运行前将无需部署的插件删除。
+> 注意，位于`build/plugins`下的插件属于 FIT 启动的内置插件，包含了 FIT 框架提供的一系列功能，并不支持运行时热插拔，用户需要在运行前将无需部署的插件删除。
 >
 > 而 FIT 用户插件目录支持插件的运行时热插拔，在配置`fit start`启动命令后，用户可以在任意位置新建一个空目录作为用户插件目录，具体配置命令的方式请参考 [FIT 用户指导手册：插件化开发](../user-guide-book/06.%20插件化开发.md)。
 

--- a/docs/framework/fit/java/quick-start-guide/03. 使用插件的热插拔能力.md
+++ b/docs/framework/fit/java/quick-start-guide/03. 使用插件的热插拔能力.md
@@ -528,7 +528,7 @@ public class OtherWeather implements Weather {
 mvn clean install
 ```
 
-创建框架目录 `fitframework`，将 `framework/fit/java/target` 文件下的所有内容复制到 `fitframework` 目录中，然后在框架同级目录创建 `custom` 目录，用于存放用户插件。例如，若框架位于目录 `D:/demo/fitframework` 下，则创建用户目录 `D:/demo/custom`。
+创建框架目录 `fitframework`，将 `build` 目录下的所有内容复制到 `fitframework` 目录中，然后在框架同级目录创建 `custom` 目录，用于存放用户插件。例如，若框架位于目录 `D:/demo/fitframework` 下，则创建用户目录 `D:/demo/custom`。
 
 > 该自定义目录位置仅用于方便演示，故放置在框架目录旁，实际是它可以是任意目录。
 

--- a/docs/framework/fit/java/user-guide-book/03. Conf 配置.md
+++ b/docs/framework/fit/java/user-guide-book/03. Conf 配置.md
@@ -97,7 +97,7 @@ fit debug -XX:MaxGCPauseMillis=200 server.http.port=8081
 ````
 
 * 支持通过命令行设置`-config-file=xx`指定配置文件路径。
-* 未指定时，默认读取`framework/fit/java/fit-runtime/src/main/resources/fitframework.yml`的配置文件，在编译后存储在`fitframework/target/conf/fitframework.yml`中。对于仅需修改框架配置文件的场景，可临时修改`fitframework/target/conf/fitframework.yml`后，无需编译直接启动。
+* 未指定时，默认读取`framework/fit/java/fit-runtime/src/main/resources/fitframework.yml`的配置文件，在编译后存储在`build/conf/fitframework.yml`中。对于仅需修改框架配置文件的场景，可临时修改`build/conf/fitframework.yml`后，无需编译直接启动。
 ### 3.3.4.2 内置配置文件
 
 以 `fit-service-registry` 插件的 `application.yml` 的示例如下：

--- a/docs/framework/fit/java/user-guide-book/06. 插件化开发.md
+++ b/docs/framework/fit/java/user-guide-book/06. 插件化开发.md
@@ -105,7 +105,7 @@ fit:
 
 ## 6.4.1 插件目录的创建
 
-- 首先用`maven`编译打包`./framework/fit/java`，将`target`目录内容存储在本地`fitframework`目录下，此目录为 FIT 核心框架目录地址。
+- 首先用`maven`编译打包`./framework/fit/java`，将`build`目录内容存储在本地`fitframework`目录下，此目录为 FIT 核心框架目录地址。
 - 配置`FIT`框架目录的系统环境变量，变量值为`FIT`核心框架目录地址，使`fit`命令可执行。例如 `FIT` 核心框架位置在`D:/demo/fitframework`，则变量值配置为`D:/demo/fitframework`。
 - 新建任意目录作为插件目录，在该目录下存放插件，可在插件目录下使用命令`fit start`启动服务。
 > 以上环境配置步骤请根据使用的操作系统使用相应的路径分隔符和环境变量配置操作。

--- a/docs/framework/fit/java/user-guide-book/08. 日志.md
+++ b/docs/framework/fit/java/user-guide-book/08. 日志.md
@@ -263,6 +263,6 @@ log.info("Hello World.");
 
 （1）在该场景下，因为项目模块只有插件模块，不含有用户自己的应用模块。所以不需要考虑 "应用模块配置"。
 
-（2）进入 framework/fit/java 目录，编译源码后，需要在 target/shared 目录下放入 log4j-api、log4j-core、log4j-slf4j-impl、slf4j-api 的 jar 包。应用启动时，SharedClassLoader 会加载 shared 目录下所有的 JAR 包并扫描里面的类。这样的话，日志相关的类将由 SharedClassLoader类加载器加载，各个插件的业务逻辑在运行过程中，通过委托机制，都能够正确获取到日志类的实现，因此可以正常打印。
+（2）编译源码后，需要在 build/shared 目录下放入 log4j-api、log4j-core、log4j-slf4j-impl、slf4j-api 的 jar 包。应用启动时，SharedClassLoader 会加载 shared 目录下所有的 JAR 包并扫描里面的类。这样的话，日志相关的类将由 SharedClassLoader类加载器加载，各个插件的业务逻辑在运行过程中，通过委托机制，都能够正确获取到日志类的实现，因此可以正常打印。
 
-（3）放置 log4j2.xml 配置文件，并在应用启动命令中加入 `log4j2.configurationFile` 的配置项用于指定配置文件的位置，并通过 `-D` 的方式配置。例如，用户可以将 log4j2.xml 配置文件放置在 target/conf 下，则启动命令为 `fit start server.http.port=8080 -Dlog4j2.configurationFile=./conf/log4j2.xml`
+（3）放置 log4j2.xml 配置文件，并在应用启动命令中加入 `log4j2.configurationFile` 的配置项用于指定配置文件的位置，并通过 `-D` 的方式配置。例如，用户可以将 log4j2.xml 配置文件放置在 build/conf 下，则启动命令为 `fit start server.http.port=8080 -Dlog4j2.configurationFile=./conf/log4j2.xml`


### PR DESCRIPTION
1.修正了文档中关于编译输出目录的描述不准确问题，使其与实际编译输出目录一致