### PR TITLE
feat: Add readOnly mode to JadeFlowEntry for history view

### DIFF
--- a/framework/elsa/fit-elsa-react/src/components/common/JadeObservableOutput.jsx
+++ b/framework/elsa/fit-elsa-react/src/components/common/JadeObservableOutput.jsx
@@ -95,18 +95,20 @@ function _JadeObservableOutput({disabled, output}) {
 
   return (<>
     <JadeCollapse defaultActiveKey={['codeOutputPanel']}>
-      {<Panel key={'codeOutputPanel'}
-              header={<div className='panel-header'>
-                <span className='jade-panel-header-font'>{t('output')}</span>
-                <Popover
-                  content={content}
-                  align={{offset: [0, 3]}}
-                  overlayClassName={'jade-custom-popover'}
-                >
-                  <QuestionCircleOutlined className='jade-panel-header-popover-content'/>
-                </Popover>
-              </div>}
-              className='jade-panel'
+      {<Panel
+        key={'codeOutputPanel'}
+        header={<div className="panel-header">
+          <span className="jade-panel-header-font">{t('output')}</span>
+          <Popover
+            content={content}
+            align={{offset: [0, 3]}}
+            overlayClassName={'jade-custom-popover'}
+          >
+            <QuestionCircleOutlined className="jade-panel-header-popover-content"/>
+          </Popover>
+        </div>}
+        className="jade-panel"
+        forceRender
       >
         <Tree blockNode={true}
               switcherIcon={({expanded}) => <TreeSwitcherIcon expanded={expanded}/>}

--- a/framework/elsa/fit-elsa-react/src/components/common/JadeObservableTree.jsx
+++ b/framework/elsa/fit-elsa-react/src/components/common/JadeObservableTree.jsx
@@ -6,7 +6,7 @@
 
 import {Tree} from "antd";
 import {useShapeContext} from "../DefaultRoot.jsx";
-import {useEffect} from "react";
+import React, {useEffect} from "react";
 import "./jadeObservableTree.css";
 import TreeSwitcherIcon from "@/components/common/TreeSwitcherIcon.jsx";
 
@@ -50,7 +50,7 @@ const buildNode = (nodeData, parent, level, shape) => {
  * @return {JSX.Element}
  * @constructor
  */
-export const JadeObservableTree = ({data}) => {
+const _JadeObservableTree = ({data}) => {
     if (!Array.isArray(data)) {
         throw new Error("data must be array.");
     }
@@ -120,3 +120,9 @@ export const JadeObservableTree = ({data}) => {
         </Tree>
     </>;
 };
+
+const areEqual = (prevProps, nextProps) => {
+    return prevProps.data === nextProps.data;
+};
+
+export const JadeObservableTree = React.memo(_JadeObservableTree, areEqual);

--- a/framework/elsa/fit-elsa-react/src/components/common/OutputForm.jsx
+++ b/framework/elsa/fit-elsa-react/src/components/common/OutputForm.jsx
@@ -43,6 +43,7 @@ const _OutputForm = ({outputParams, outputPopover}) => {
         }
         className='jade-panel'
         key='Output'
+        forceRender
       >
         <div className={'jade-custom-panel-content'}>
           <JadeObservableTree data={outputParams}/>

--- a/framework/elsa/fit-elsa-react/src/components/condition/conditionNodeCondition.jsx
+++ b/framework/elsa/fit-elsa-react/src/components/condition/conditionNodeCondition.jsx
@@ -59,7 +59,6 @@ export const conditionNodeCondition = (id, x, y, width, height, parent, drawer) 
      * @override
      */
     self.serializerJadeConfig = (jadeConfig) => {
-      jadeConfig.branches.forEach(branch => delete branch.disabled);
       self.flowMeta.conditionParams = jadeConfig;
       self.flowMeta.enableStageDesc = self.flowMeta.conditionParams.enableStageDesc;
       self.flowMeta.stageDesc = self.flowMeta.conditionParams.stageDesc;

--- a/framework/elsa/fit-elsa-react/src/components/llm/LlmOutput.jsx
+++ b/framework/elsa/fit-elsa-react/src/components/llm/LlmOutput.jsx
@@ -32,29 +32,6 @@ _LlmOutput.propTypes = {
  */
 function _LlmOutput({outputItems, enableLogData, disabled}) {
     const dispatch = useDispatch();
-    // 430演示大模型输出不需要新增和删除，暂时屏蔽
-    // 添加新元素到 items 数组中，并将其 key 添加到当前展开的面板数组中
-    // const addItem = () => {
-    //     dispatch({actionType: "addOutputParam", id: "uuidv4()})
-    // };
- 
-    // 430演示大模型输出不允许用户修改，暂时屏蔽
-    // const handleItemChange = (name, value, itemId) => {
-    //     dispatch({actionType: "changeOutputParam", id: itemId, type: name, value: value});
-    //     if (name === "type") {
-    //         document.activeElement.blur();// 在选择后取消焦点
-    //     }
-    // };
- 
-    // 430演示大模型输出不需要新增和删除，暂时屏蔽
-    // const handleDelete = (itemId) => {
-    //     dispatch({actionType: "deleteOutputParam", id: itemId});
-    // };
- 
-    // 430演示大模型输出不需要新增和删除，暂时屏蔽
-    // const handleSelectClick = (event) => {
-    //     event.stopPropagation(); // 阻止事件冒泡
-    // };
     const {t} = useTranslation();
  
     const content = (
@@ -79,18 +56,10 @@ function _LlmOutput({outputItems, enableLogData, disabled}) {
                             >
                                 <QuestionCircleOutlined className="jade-panel-header-popover-content"/>
                             </Popover>
-                            {/* 430演示大模型输出不需要新增和删除，暂时屏蔽*/}
-                            {/* <Button type="text" className="icon-button"*/}
-                            {/*        style={{"height": "22px", "marginLeft": "auto"}}*/}
-                            {/*        onClick={(event) => {*/}
-                            {/*            addItem();*/}
-                            {/*            handleSelectClick(event);*/}
-                            {/*        }}>*/}
-                            {/*    <PlusOutlined/>*/}
-                            {/* </Button>*/}
                         </div>
                     }
                     className="jade-panel"
+                    forceRender
                 >
                     <div className={"jade-custom-panel-content"}>
                         <Form.Item className='jade-form-item' name={`enableLog-${enableLogData.id}`}>
@@ -99,93 +68,6 @@ function _LlmOutput({outputItems, enableLogData, disabled}) {
                               className={'jade-font-size'}>{t('pushResultToChat')}</span></Checkbox>
                         </Form.Item>
                         <JadeObservableTree data={outputItems}/>
-                        {/* 430演示大模型输出不允许用户操作，写死*/}
-                        {/* <Row gutter={16}>*/}
-                        {/*    <Col span={7}>*/}
-                        {/*        <Form.Item>*/}
-                        {/*            <span style={{color: "rgba(28,31,35,.35)"}}>Name</span>*/}
-                        {/*        </Form.Item>*/}
-                        {/*    </Col>*/}
-                        {/*    <Col span={5}>*/}
-                        {/*        <Form.Item>*/}
-                        {/*            <span style={{color: "rgba(28,31,35,.35)"}}>Type</span>*/}
-                        {/*        </Form.Item>*/}
-                        {/*    </Col>*/}
-                        {/*    <Col span={12}>*/}
-                        {/*        <Form.Item>*/}
-                        {/*            <span style={{color: "rgba(28,31,35,.35)"}}>Description</span>*/}
-                        {/*        </Form.Item>*/}
-                        {/*    </Col>*/}
-                        {/* </Row>*/}
-                        {/* 430演示大模型输出不允许用户操作，写死*/}
-                        {/* {outputItems.map((item) => (*/}
-                        {/*    <Row*/}
-                        {/*        key={item.id}*/}
-                        {/*        gutter={16}*/}
-                        {/*    >*/}
-                        {/* <Col span={7}>*/}
-                        {/*    <Form.Item*/}
-                        {/*        id={`name-${item.id}`}*/}
-                        {/*        name={`name-${item.id}`}*/}
-                        {/*        rules={[{required: true, message: '输出参数名称不能为空!'}]}*/}
-                        {/*        initialValue={item.name}*/}
-                        {/*    >*/}
-                        {/*        <JInput*/}
-                        {/*            style={{paddingRight: "12px"}}*/}
-                        {/*            value={item.name}*/}
-                        {/*            onChange={(e) => handleItemChange('name', e.target.value, item.id)}*/}
-                        {/*        />*/}
-                        {/*    </Form.Item>*/}
-                        {/* </Col>*/}
-                        {/* <Col span={5}>*/}
-                        {/*    <Form.Item*/}
-                        {/*        id={`type-${item.id}`}*/}
-                        {/*        initialValue='String'*/}
-                        {/*    >*/}
-                        {/*        <JadeStopPropagationSelect*/}
-                        {/*            id={`type-select-${item.id}`}*/}
-                        {/*            style={{width: "100%"}}*/}
-                        {/*            onChange={(value) => handleItemChange('type', value, item.id)}*/}
-                        {/*            options={[*/}
-                        {/*                {value: 'String', label: 'String'},*/}
-                        {/*                {value: 'Integer', label: 'Integer'},*/}
-                        {/*                {value: 'Boolean', label: 'Boolean'},*/}
-                        {/*                {value: 'Number', label: 'Number'},*/}
-                        {/*                {value: 'Object', label: 'Object', disabled: true},*/}
-                        {/*                {value: 'Array<String>', label: 'Array<String>'},*/}
-                        {/*                {value: 'Array<Integer>', label: 'Array<Integer>'},*/}
-                        {/*                {value: 'Array<Boolean>', label: 'Array<Boolean>'},*/}
-                        {/*                {value: 'Array<Number>', label: 'Array<Number>'},*/}
-                        {/*                {value: 'Array<Object>', label: 'Array<Object>', disabled: true},*/}
-                        {/*            ]}*/}
-                        {/*            value={item.type}*/}
-                        {/*        />*/}
-                        {/*    </Form.Item>*/}
-                        {/* </Col>*/}
-                        {/* <Col span={11}>*/}
-                        {/*    <Form.Item*/}
-                        {/*        id={`description-${item.id}`}*/}
-                        {/*    >*/}
-                        {/*        <JInput*/}
-                        {/*            style={{paddingRight: "12px"}}*/}
-                        {/*            value={item.description}*/}
-                        {/*            onChange={(e) => handleItemChange('description', e.target.value, item.id)}*/}
-                        {/*        />*/}
-                        {/*    </Form.Item>*/}
-                        {/* </Col>*/}
-
-                        {/* 430演示大模型输出不需要新增和删除，暂时屏蔽*/}
-                        {/* <Col span={1} style={{paddingLeft: "2px"}}>*/}
-                        {/*    <Form.Item>*/}
-                        {/*        <Button type="text" className="icon-button"*/}
-                        {/*                style={{"height": "100%", "marginLeft": "auto"}}*/}
-                        {/*                onClick={() => handleDelete(item.id)}>*/}
-                        {/*            <MinusCircleOutlined/>*/}
-                        {/*        </Button>*/}
-                        {/*    </Form.Item>*/}
-                        {/* </Col>*/}
-                        {/* </Row>*/}
-                        {/* ))}*/}
                     </div>
                 </Panel>
             }

--- a/framework/elsa/fit-elsa-react/src/components/util/BranchUtil.js
+++ b/framework/elsa/fit-elsa-react/src/components/util/BranchUtil.js
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) 2025 Huawei Technologies Co., Ltd. All rights reserved.
+ *  This file is a part of the ModelEngine Project.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export const setBranchDisabled = (node, disabled) => {
+  const flowMeta = node.getFlowMeta();
+  node.drawer.dispatch({
+    actionType: 'changeBranchesStatus',
+    changes: [
+      {key: 'ids', value: flowMeta.conditionParams.branches.map(b => b.id)},
+      {key: 'disabled', value: disabled},
+      {key: 'jadeNodeConfigChangeIgnored', value: true},
+    ],
+  });
+};

--- a/framework/elsa/fit-elsa-react/src/flow/jadeFlowEntry.jsx
+++ b/framework/elsa/fit-elsa-react/src/flow/jadeFlowEntry.jsx
@@ -8,6 +8,7 @@ import {jadeFlowGraph} from './jadeFlowGraph.js';
 import {jadeEvaluationGraph} from '@/flow/evaluation/jadeEvaluationGraph.js';
 import {ShapeDataValidationProcessor} from '@/data/ShapeDataValidationProcessor.js';
 import {SYSTEM_ACTION} from '@/common/Consts.js';
+import {setBranchDisabled} from '@/components/util/BranchUtil.js';
 
 /**
  * react流程代码，对外暴露接口，以便对流程进行操作以及获取数据.
@@ -222,10 +223,10 @@ const jadeFlowAgent = (graph) => {
         shape.statusManager.setDisabled(true);
         shape.statusManager.setReferenceDisabled(true);
         shape.moveable = false;
+        if (shape.isTypeof('conditionNodeCondition')) {
+          setBranchDisabled(shape, true);
+        }
       });
-      // if (shape.isTypeof('conditionNodeCondition')) {
-      //
-      // }
     });
   };
 

--- a/framework/elsa/fit-elsa-react/src/flow/jadeFlowEntry.jsx
+++ b/framework/elsa/fit-elsa-react/src/flow/jadeFlowEntry.jsx
@@ -13,118 +13,118 @@ import {SYSTEM_ACTION} from '@/common/Consts.js';
  * react流程代码，对外暴露接口，以便对流程进行操作以及获取数据.
  */
 const jadeFlowAgent = (graph) => {
-    const self = {};
-    self.graph = graph;
+  const self = {};
+  self.graph = graph;
 
-    /**
-     * 添加图形.
-     *
-     * @param shapeType 图形类型.
-     * @param properties 初始化属性.
-     */
-    self.want = (shapeType, properties) => {
-        graph.activePage.want(shapeType, properties);
-    };
+  /**
+   * 添加图形.
+   *
+   * @param shapeType 图形类型.
+   * @param properties 初始化属性.
+   */
+  self.want = (shapeType, properties) => {
+    graph.activePage.want(shapeType, properties);
+  };
 
-    /**
-     * 导入用户自定义组件.
-     *
-     * @param importStatement import语句.
-     * @return {*}
-     */
-    self.import = (importStatement) => {
-        return self.graph.staticImport(importStatement);
-    };
+  /**
+   * 导入用户自定义组件.
+   *
+   * @param importStatement import语句.
+   * @return {*}
+   */
+  self.import = (importStatement) => {
+    return self.graph.staticImport(importStatement);
+  };
 
-    /**
-     * 序列化数据.
-     *
-     * @returns {*} 流程的全量序列化数据.
-     */
-    self.serialize = () => {
-        graph.activePage.serialize();
-        return graph.serialize();
-    };
+  /**
+   * 序列化数据.
+   *
+   * @returns {*} 流程的全量序列化数据.
+   */
+  self.serialize = () => {
+    graph.activePage.serialize();
+    return graph.serialize();
+  };
 
-    /**
-     * 获取流程试运行入参元数据
-     */
-    self.getFlowRunInputMetaData = () => {
-        return graph.activePage.sm.findShapeBy(s => s.type === 'startNodeStart').getRunInputParams();
-    };
+  /**
+   * 获取流程试运行入参元数据
+   */
+  self.getFlowRunInputMetaData = () => {
+    return graph.activePage.sm.findShapeBy(s => s.type === 'startNodeStart').getRunInputParams();
+  };
 
-    /**
-     * 运行流程.
-     *
-     * @return {*} 通过refresh刷新流程状态，通过reset重置流程，通过stop结束流程.
-     */
-    self.run = () => {
-        const nodes = graph.activePage.testRun();
-        return {
-            // 刷新流程节点状态.
-            refresh: (dataList) => graph.activePage.refreshRun(nodes, dataList),
-            // 重置流程节点装填.
-            reset: () => graph.activePage.resetRun(nodes),
-            // 结束运行.
-            stop: (dataList) => graph.activePage.stopRun(nodes, dataList)
-        };
+  /**
+   * 运行流程.
+   *
+   * @return {*} 通过refresh刷新流程状态，通过reset重置流程，通过stop结束流程.
+   */
+  self.run = () => {
+    const nodes = graph.activePage.testRun();
+    return {
+      // 刷新流程节点状态.
+      refresh: (dataList) => graph.activePage.refreshRun(nodes, dataList),
+      // 重置流程节点装填.
+      reset: () => graph.activePage.resetRun(nodes),
+      // 结束运行.
+      stop: (dataList) => graph.activePage.stopRun(nodes, dataList),
     };
+  };
 
-    /**
-     * 获取可创建的节点列表.
-     */
-    self.getAvailableNodes = () => {
-        return [
-            {type: 'retrievalNodeState', name: '数据检索'},
-            {type: 'llmNodeState', name: '大模型'},
-            {type: 'manualCheckNodeState', name: '人工检查'},
-            {type: 'fitInvokeNodeState', name: 'FIT调用'},
-        ];
-    };
+  /**
+   * 获取可创建的节点列表.
+   */
+  self.getAvailableNodes = () => {
+    return [
+      {type: 'retrievalNodeState', name: '数据检索'},
+      {type: 'llmNodeState', name: '大模型'},
+      {type: 'manualCheckNodeState', name: '人工检查'},
+      {type: 'fitInvokeNodeState', name: 'FIT调用'},
+    ];
+  };
 
-    /**
-     * 创建节点.
-     *
-     * @param type 节点类型.
-     * @param e 鼠标事件.
-     * @param metaData 元数据
-     */
-    self.createNode = (type, e, metaData) => {
-        const position = graph.activePage.calculatePosition(e);
-        graph.activePage.createNew(type, position.x, position.y, null, null, null, null, null, metaData);
-    };
+  /**
+   * 创建节点.
+   *
+   * @param type 节点类型.
+   * @param e 鼠标事件.
+   * @param metaData 元数据
+   */
+  self.createNode = (type, e, metaData) => {
+    const position = graph.activePage.calculatePosition(e);
+    graph.activePage.createNew(type, position.x, position.y, null, null, null, null, null, metaData);
+  };
 
-    /**
-     * 创建工具节点
-     *
-     * @param e 鼠标事件.
-     * @param schemaData schema元数据
-     */
-    self.createTool = (e, schemaData) => {
-        const position = graph.activePage.calculatePosition(e);
-        self.createToolByPosition(position, schemaData);
-    };
+  /**
+   * 创建工具节点
+   *
+   * @param e 鼠标事件.
+   * @param schemaData schema元数据
+   */
+  self.createTool = (e, schemaData) => {
+    const position = graph.activePage.calculatePosition(e);
+    self.createToolByPosition(position, schemaData);
+  };
 
-    /**
-     * 创建节点.
-     *
-     * @param type 节点类型.
-     * @param position 坐标.
-     * @param metaData 元数据
-     */
-    self.createNodeByPosition = (type, position, metaData) => {
-        graph.activePage.createNew(type, position.x, position.y, null, null, null, null, null, metaData);
-    };
+  /**
+   * 创建节点.
+   *
+   * @param type 节点类型.
+   * @param position 坐标.
+   * @param metaData 元数据
+   */
+  self.createNodeByPosition = (type, position, metaData) => {
+    graph.activePage.createNew(type, position.x, position.y, null, null, null, null, null, metaData);
+  };
 
-    /**
-     * 创建工具节点
-     *
-     * @param position 坐标.
-     * @param schemaData schema元数据
-     */
-    self.createToolByPosition = (position, schemaData) => {
-        graph.activePage.createNew('toolInvokeNodeState', position.x, position.y, null, null, null, null, null, schemaData);
-    };
+  /**
+   * 创建工具节点
+   *
+   * @param position 坐标.
+   * @param schemaData schema元数据
+   */
+  self.createToolByPosition = (position, schemaData) => {
+    graph.activePage.createNew('toolInvokeNodeState', position.x, position.y, null, null, null, null, null, schemaData);
+  };
 
   /**
    * 画布发生变化时触发.
@@ -163,120 +163,137 @@ const jadeFlowAgent = (graph) => {
     };
   };
 
-    /**
-     * 获取所有节点的配置数据.
-     * 返回格式: {
-     *     'nodeId': [] // 这里的数组是每个节点的配置数据.
-     * }
-     *
-     * @return {*} 返回配置数据.
-     */
-    self.getNodeConfigs = () => {
-        return graph.activePage.sm.getShapes(s => s.isTypeof('jadeNode')).map(s => {
-            return {
-                [s.id]: s.drawer.getLatestJadeConfig()
-            };
-        });
-    };
+  /**
+   * 获取所有节点的配置数据.
+   * 返回格式: {
+   *     'nodeId': [] // 这里的数组是每个节点的配置数据.
+   * }
+   *
+   * @return {*} 返回配置数据.
+   */
+  self.getNodeConfigs = () => {
+    return graph.activePage.sm.getShapes(s => s.isTypeof('jadeNode')).map(s => {
+      return {
+        [s.id]: s.drawer.getLatestJadeConfig(),
+      };
+    });
+  };
 
-    /**
-     * 校验所有节点数据是否合法.
-     *
-     * @return Promise 校验结果
-     */
-    self.validate = async (validateInfo, refresh) => {
-        const createRecursiveProxy = (target, re) => {
-            if (typeof target === 'object' && target !== null) {
-                return new Proxy(target, {
-                    get(tar, prop) {
-                        const value = tar[prop];
-                        // 如果属性值是对象或数组，递归包装
-                        if (typeof value === 'object' && value !== null) {
-                            return createRecursiveProxy(value, re);
-                        }
-                        return value;
-                    },
-                    set(tar, prop, value) {
-                        tar[prop] = value;
-                        re(self.graph.validateInfo); // 触发刷新
-                        return true;
-                    },
-                });
+  /**
+   * 校验所有节点数据是否合法.
+   *
+   * @return Promise 校验结果
+   */
+  self.validate = async (validateInfo, refresh) => {
+    const createRecursiveProxy = (target, re) => {
+      if (typeof target === 'object' && target !== null) {
+        return new Proxy(target, {
+          get(tar, prop) {
+            const value = tar[prop];
+            // 如果属性值是对象或数组，递归包装
+            if (typeof value === 'object' && value !== null) {
+              return createRecursiveProxy(value, re);
             }
-            return target;
-        };
-
-        if (validateInfo && refresh) {
-            self.graph.validateInfo = createRecursiveProxy(validateInfo, refresh);
-        }
-        return await graph.activePage.validate();
-    };
-
-    /**
-     * 添加事件监听并执行回调函数.
-     *
-     * @param eventType 事件类型.
-     * @param callback 回调函数.
-     */
-    const addSelectEventListener = (eventType, callback) => {
-        graph.activePage.addEventListener(eventType, (event) => {
-            callback(event);
+            return value;
+          },
+          set(tar, prop, value) {
+            tar[prop] = value;
+            re(self.graph.validateInfo); // 触发刷新
+            return true;
+          },
         });
+      }
+      return target;
     };
 
-    /**
-     * 当需要触发模型选择时的回调.
-     *
-     * @param callback 回调函数.
-     */
-    self.onModelSelect = (callback) => {
-        addSelectEventListener('SELECT_MODEL', callback);
-    };
+    if (validateInfo && refresh) {
+      self.graph.validateInfo = createRecursiveProxy(validateInfo, refresh);
+    }
+    return await graph.activePage.validate();
+  };
 
-    /**
-     * 当点击创建测试集按钮时的回调.
-     *
-     * @param callback 回调函数.
-     */
-    self.onCreateButtonClick = (callback) => {
-        addSelectEventListener('CREATE_TEST_SET', callback);
-    };
+  /**
+   * 将graph设置为只读模式
+   */
+  self.readOnly = () => {
+    const page = self.graph.activePage;
+    page.reorderNodes(page.getNodes(), page.getReachableNodes(page.getStartNode())).forEach(shape => {
+      shape.ignoreChange(() => {
+        shape.statusManager.setDisabled(true);
+        shape.statusManager.setReferenceDisabled(true);
+        shape.moveable = false;
+      });
+      // if (shape.isTypeof('conditionNodeCondition')) {
+      //
+      // }
+    });
+  };
 
-    /**
-     * 当点击导入工具按钮时的回调.
-     *
-     * @param callback 回调函数.
-     */
-    self.onImportButtonClick = (callback) => {
-        addSelectEventListener('SELECT_TOOL', callback);
-    };
+  /**
+   * 添加事件监听并执行回调函数.
+   *
+   * @param eventType 事件类型.
+   * @param callback 回调函数.
+   */
+  const addSelectEventListener = (eventType, callback) => {
+    graph.activePage.addEventListener(eventType, (event) => {
+      callback(event);
+    });
+  };
 
-    /**
-     * 当需要触发知识库选择时的回调.
-     *
-     * @param callback 回调函数.
-     */
-    self.onKnowledgeBaseSelect = (callback) => {
-        addSelectEventListener('SELECT_KNOWLEDGE_BASE', callback);
-    };
+  /**
+   * 当需要触发模型选择时的回调.
+   *
+   * @param callback 回调函数.
+   */
+  self.onModelSelect = (callback) => {
+    addSelectEventListener('SELECT_MODEL', callback);
+  };
 
-    /**
-     * 当需要触发插件选择时的回调.
-     *
-     * @param callback 回调函数.
-     */
-    self.onPluginSelect = (callback) => {
-        addSelectEventListener('SELECT_PLUGIN', callback);
-    };
+  /**
+   * 当点击创建测试集按钮时的回调.
+   *
+   * @param callback 回调函数.
+   */
+  self.onCreateButtonClick = (callback) => {
+    addSelectEventListener('CREATE_TEST_SET', callback);
+  };
 
-    /**
-     * 插件选择框中选择了某个工具、工具流或者智能体.
-     *
-     * @param callback 回调函数.
-     */
-    self.onToolSelect = (callback) => {
-        addSelectEventListener('SELECT_SKILL', callback);
-    };
+  /**
+   * 当点击导入工具按钮时的回调.
+   *
+   * @param callback 回调函数.
+   */
+  self.onImportButtonClick = (callback) => {
+    addSelectEventListener('SELECT_TOOL', callback);
+  };
+
+  /**
+   * 当需要触发知识库选择时的回调.
+   *
+   * @param callback 回调函数.
+   */
+  self.onKnowledgeBaseSelect = (callback) => {
+    addSelectEventListener('SELECT_KNOWLEDGE_BASE', callback);
+  };
+
+  /**
+   * 当需要触发插件选择时的回调.
+   *
+   * @param callback 回调函数.
+   */
+  self.onPluginSelect = (callback) => {
+    addSelectEventListener('SELECT_PLUGIN', callback);
+  };
+
+  /**
+   * 插件选择框中选择了某个工具、工具流或者智能体.
+   *
+   * @param callback 回调函数.
+   */
+  self.onToolSelect = (callback) => {
+    addSelectEventListener('SELECT_SKILL', callback);
+  };
 
   /**
    * 循环节点选择框中选择了某个工具、工具流.
@@ -296,44 +313,44 @@ const jadeFlowAgent = (graph) => {
     addSelectEventListener('SELECT_PARALLEL_PLUGINS', callback);
   };
 
-    /**
-     * 当需要触发搜索参数配置时的回调.
-     *
-     * @param callback 回调函数.
-     */
-    self.onKnowledgeSearchArgsSelect = (callback) => {
-        addSelectEventListener('KNOWLEDGE_SEARCH_ARGS_EVENT', callback);
-    };
+  /**
+   * 当需要触发搜索参数配置时的回调.
+   *
+   * @param callback 回调函数.
+   */
+  self.onKnowledgeSearchArgsSelect = (callback) => {
+    addSelectEventListener('KNOWLEDGE_SEARCH_ARGS_EVENT', callback);
+  };
 
-    /**
-     * 监听某个事件.
-     *
-     * @param event 事件类型.
-     * @param listener 监听器.
-     */
-    self.listen = (event, listener) => {
-        graph.activePage.addEventListener(event, (e) => {
-            listener(e);
-        });
-    };
+  /**
+   * 监听某个事件.
+   *
+   * @param event 事件类型.
+   * @param listener 监听器.
+   */
+  self.listen = (event, listener) => {
+    graph.activePage.addEventListener(event, (e) => {
+      listener(e);
+    });
+  };
 
-    /**
-     * 将画布中心移至某个图形处.
-     *
-     * @param shapeId 需要聚焦到的图形id.
-     */
-    self.scrollToShape = (shapeId) => {
-        graph.activePage.shapes.find(s => s.id === shapeId).toScreenCenter();
-    };
+  /**
+   * 将画布中心移至某个图形处.
+   *
+   * @param shapeId 需要聚焦到的图形id.
+   */
+  self.scrollToShape = (shapeId) => {
+    graph.activePage.shapes.find(s => s.id === shapeId).toScreenCenter();
+  };
 
-    /**
-     * 当需要触发表单选择时的回调.
-     *
-     * @param callback 回调函数.
-     */
-    self.onFormSelect = (callback) => {
-        addSelectEventListener('SELECT_FORM_BASE', callback);
-    };
+  /**
+   * 当需要触发表单选择时的回调.
+   *
+   * @param callback 回调函数.
+   */
+  self.onFormSelect = (callback) => {
+    addSelectEventListener('SELECT_FORM_BASE', callback);
+  };
 
   /**
    * 当需要销毁agent时调用.
@@ -342,132 +359,132 @@ const jadeFlowAgent = (graph) => {
     graph.destroy();
   };
 
-    return self;
+  return self;
 };
 
 /**
  * Aipp流程对外接口.
  */
 export const JadeFlow = (() => {
-    const self = {};
+  const self = {};
 
-    /**
-     * 新建流程.
-     *
-     * @param div 待渲染的dom元素.
-     * @param tenant 租户.
-     * @param configs 传入的其他参数列表.
-     */
-    self.new = async (div, tenant, configs) => {
-        const graphDom = getGraphDom(div);
-        const g = jadeFlowGraph(graphDom, 'jadeFlow');
-        g.configs = configs;
-        g.collaboration.mute = true;
-        g.tenant = tenant;
-        await g.initialize();
-        const page = g.addPage('newFlowPage');
+  /**
+   * 新建流程.
+   *
+   * @param div 待渲染的dom元素.
+   * @param tenant 租户.
+   * @param configs 传入的其他参数列表.
+   */
+  self.new = async (div, tenant, configs) => {
+    const graphDom = getGraphDom(div);
+    const g = jadeFlowGraph(graphDom, 'jadeFlow');
+    g.configs = configs;
+    g.collaboration.mute = true;
+    g.tenant = tenant;
+    await g.initialize();
+    const page = g.addPage('newFlowPage');
 
-        // 新建的默认创建出start、end和一个连线
-        const start = page.createShape('startNodeStart', 100, 100);
-        const end = page.createShape('endNodeEnd', start.x + start.width + 200, 100);
-        const jadeEvent = page.createNew('jadeEvent', 0, 0);
-        page.reset();
+    // 新建的默认创建出start、end和一个连线
+    const start = page.createShape('startNodeStart', 100, 100);
+    const end = page.createShape('endNodeEnd', start.x + start.width + 200, 100);
+    const jadeEvent = page.createNew('jadeEvent', 0, 0);
+    page.reset();
 
-        // reset完成之后进行connect操作.
-        jadeEvent.connect(start.id, 'E', end.id, 'W');
+    // reset完成之后进行connect操作.
+    jadeEvent.connect(start.id, 'E', end.id, 'W');
 
-        page.fillScreen();
-        return jadeFlowAgent(g);
-    };
+    page.fillScreen();
+    return jadeFlowAgent(g);
+  };
 
-    /**
-     * 编辑流程.
-     *
-     * @param div 待渲染的dom元素.
-     * @param tenant 租户.
-     * @param appId appId
-     * @param flowConfigData 流程元数据.
-     * @param configs 传入的其他参数列表.
-     * @param i18n 传入的多语言翻译组件.
-     * @param importStatements 传入的需要加载的语句.
-     * @param flowType 流程类型.
-     */
-    self.edit = async ({
-                           div,
-                           tenant,
-                           appId,
-                           flowConfigData,
-                           configs,
-                           i18n,
-                           importStatements = [],
-                           flowType = 'app',
-                       }) => {
-        const graphDom = getGraphDom(div);
-        const g = jadeFlowGraph(div, 'jadeFlow');
-        await configGraph(g, tenant, appId, flowConfigData, configs, i18n, importStatements);
-        g.flowType = flowType;
-        const pageData = g.getPageData(0);
-        await g.editFlow(0, graphDom, pageData.id);
-        await g.activePage.awaitShapesRendered();
-        return jadeFlowAgent(g);
-    };
+  /**
+   * 编辑流程.
+   *
+   * @param div 待渲染的dom元素.
+   * @param tenant 租户.
+   * @param appId appId
+   * @param flowConfigData 流程元数据.
+   * @param configs 传入的其他参数列表.
+   * @param i18n 传入的多语言翻译组件.
+   * @param importStatements 传入的需要加载的语句.
+   * @param flowType 流程类型.
+   */
+  self.edit = async ({
+                       div,
+                       tenant,
+                       appId,
+                       flowConfigData,
+                       configs,
+                       i18n,
+                       importStatements = [],
+                       flowType = 'app',
+                     }) => {
+    const graphDom = getGraphDom(div);
+    const g = jadeFlowGraph(div, 'jadeFlow');
+    await configGraph(g, tenant, appId, flowConfigData, configs, i18n, importStatements);
+    g.flowType = flowType;
+    const pageData = g.getPageData(0);
+    await g.editFlow(0, graphDom, pageData.id);
+    await g.activePage.awaitShapesRendered();
+    return jadeFlowAgent(g);
+  };
 
-    /**
-     * 评估流程.
-     *
-     * @param div 待渲染的dom元素.
-     * @param tenant 租户.
-     * @param appId appId.
-     * @param flowConfigData 流程元数据.
-     * @param isPublished 是否已发布.
-     * @param configs 传入的其他参数列表.
-     * @param i18n 传入的多语言翻译组件.
-     * @param importStatements 传入的需要加载的语句.
-     * @return {Promise<{}>} JadeFlowAgent代理.
-     */
-    self.evaluate = async (div, tenant, appId, flowConfigData, isPublished, configs, i18n, importStatements = []) => {
-        const graphDom = getGraphDom(div);
-        const g = jadeEvaluationGraph(graphDom, 'jadeEvaluation');
-        await configGraph(g, tenant, appId, flowConfigData, configs, i18n, importStatements);
-        await g.evaluate(flowConfigData, isPublished);
-        await g.activePage.awaitShapesRendered();
-        return jadeFlowAgent(g);
-    };
+  /**
+   * 评估流程.
+   *
+   * @param div 待渲染的dom元素.
+   * @param tenant 租户.
+   * @param appId appId.
+   * @param flowConfigData 流程元数据.
+   * @param isPublished 是否已发布.
+   * @param configs 传入的其他参数列表.
+   * @param i18n 传入的多语言翻译组件.
+   * @param importStatements 传入的需要加载的语句.
+   * @return {Promise<{}>} JadeFlowAgent代理.
+   */
+  self.evaluate = async (div, tenant, appId, flowConfigData, isPublished, configs, i18n, importStatements = []) => {
+    const graphDom = getGraphDom(div);
+    const g = jadeEvaluationGraph(graphDom, 'jadeEvaluation');
+    await configGraph(g, tenant, appId, flowConfigData, configs, i18n, importStatements);
+    await g.evaluate(flowConfigData, isPublished);
+    await g.activePage.awaitShapesRendered();
+    return jadeFlowAgent(g);
+  };
 
-    const configGraph = async (g, tenant, appId, flowConfigData, configs, i18n, importStatements) => {
-        g.collaboration.mute = true;
-        g.configs = configs;
-        g.i18n = i18n;
-        for (let i = 0; i < importStatements.length; i++) {
-            await g.dynamicImportStatement(importStatements[i]);
-        }
-        await g.initialize();
-        g.deSerialize(flowConfigData);
-        g.tenant = tenant;
-        g.appId = appId;
-        return g;
-    };
+  const configGraph = async (g, tenant, appId, flowConfigData, configs, i18n, importStatements) => {
+    g.collaboration.mute = true;
+    g.configs = configs;
+    g.i18n = i18n;
+    for (let i = 0; i < importStatements.length; i++) {
+      await g.dynamicImportStatement(importStatements[i]);
+    }
+    await g.initialize();
+    g.deSerialize(flowConfigData);
+    g.tenant = tenant;
+    g.appId = appId;
+    return g;
+  };
 
-    /**
-     * 创建一个新的用于承载elsa graph内容的dom元素
-     *
-     * @param parentDom 父dom
-     * @return {HTMLElement|HTMLDivElement}
-     */
-    const getGraphDom = (parentDom) => {
-        const graphDom = document.getElementById('elsa-graph');
-        if (graphDom) {
-            return graphDom;
-        } else {
-            const newGraphDom = document.createElement('div');
-            newGraphDom.style.width = `${parentDom.clientWidth}px`;
-            newGraphDom.style.height = `${parentDom.clientHeight}px`;
-            newGraphDom.style.position = 'relative';
-            newGraphDom.id = 'elsa-graph';
-            parentDom.appendChild(newGraphDom);
-            return newGraphDom;
-        }
-    };
+  /**
+   * 创建一个新的用于承载elsa graph内容的dom元素
+   *
+   * @param parentDom 父dom
+   * @return {HTMLElement|HTMLDivElement}
+   */
+  const getGraphDom = (parentDom) => {
+    const graphDom = document.getElementById('elsa-graph');
+    if (graphDom) {
+      return graphDom;
+    } else {
+      const newGraphDom = document.createElement('div');
+      newGraphDom.style.width = `${parentDom.clientWidth}px`;
+      newGraphDom.style.height = `${parentDom.clientHeight}px`;
+      newGraphDom.style.position = 'relative';
+      newGraphDom.id = 'elsa-graph';
+      parentDom.appendChild(newGraphDom);
+      return newGraphDom;
+    }
+  };
 
-    return self;
+  return self;
 })();

--- a/framework/elsa/fit-elsa-react/src/flow/jadeFlowPage.js
+++ b/framework/elsa/fit-elsa-react/src/flow/jadeFlowPage.js
@@ -420,7 +420,7 @@ export const jadeFlowPage = (div, graph, name, id) => {
    * const sortedNodes = reorderNodes(nodes, orderedNodes);
    * console.log(sortedNodes); // 输出: ['A', 'B', 'X', 'Y', 'Z']
    */
-  const reorderNodes = (nodes, orderedNodes) => {
+  self.reorderNodes = (nodes, orderedNodes) => {
     // 创建一个 Map，用于快速查找节点在 reachableNodes 中的索引
     const nodeOrder = new Map();
     orderedNodes.forEach((node, index) => {
@@ -453,7 +453,7 @@ export const jadeFlowPage = (div, graph, name, id) => {
     });
     self.isRunning = true;
     const nodes = allNodes.filter(s => s.runnable !== false);
-    const orderedNodes = reorderNodes(nodes, reachableNodes);
+    const orderedNodes = self.reorderNodes(nodes, reachableNodes);
     orderedNodes.map(n => {
       const runner = self.createRunner(n);
       n.ignoreChange(() => runner.testRun());

--- a/framework/elsa/fit-elsa-react/src/flow/runners.js
+++ b/framework/elsa/fit-elsa-react/src/flow/runners.js
@@ -5,6 +5,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import {NODE_STATUS} from '@';
+import {setBranchDisabled} from '@/components/util/BranchUtil.js';
 
 /**
  * 正常页面中节点运行时 runner.
@@ -116,17 +117,9 @@ export const conditionRunner = (node) => {
         _setBranchDisable(false);
     };
 
-  const _setBranchDisable = (disabled) => {
-    const flowMeta = node.getFlowMeta();
-    node.drawer.dispatch({
-      actionType: 'changeBranchesStatus',
-      changes: [
-        {key: 'ids', value: flowMeta.conditionParams.branches.map(b => b.id)},
-        {key: 'disabled', value: disabled},
-        {key: 'jadeNodeConfigChangeIgnored', value: true},
-      ],
-    });
-  };
+    const _setBranchDisable = (disabled) => {
+        setBranchDisabled(node, disabled);
+    };
 
     return self;
 };


### PR DESCRIPTION
This PR introduces a readOnly mode in JadeFlowEntry to support historical version browsing:

Adds readOnly method to disable editing in history view.
Enhances condition node handling to ensure branches remain read-only.
Fixes serialization to preserve disabled state.

Testing:
Verify nodes & condition branches are uneditable in history mode.
Ensure disabled state persists after serialization.