### PR TITLE
[fit] upgrade tornado from 6.4.2 to 6.5.0

### DIFF
--- a/framework/fit/python/requirements.txt
+++ b/framework/fit/python/requirements.txt
@@ -1,4 +1,4 @@
 numpy==1.25.2
 PyYAML==6.0.1
 requests==2.32.0
-tornado==6.4.2
+tornado==6.5.0


### PR DESCRIPTION
Upgrade tornado (FIT for Python) from 6.4.2 to 6.5.0