### PR TITLE
[elsa] fix(JadeReferenceTreeSelect): Force reference updates on same selection

### DIFF
--- a/framework/elsa/fit-elsa-react/src/components/common/JadeReferenceTreeSelect.jsx
+++ b/framework/elsa/fit-elsa-react/src/components/common/JadeReferenceTreeSelect.jsx
@@ -52,10 +52,6 @@ export const JadeReferenceTreeSelect = (props) => {
       return;
     }
 
-    // 重复选择相同的选项，不进行处理.
-    if (selected === reference.referenceId) {
-      return;
-    }
     const treeMap = new Map(treeData.map(d => [d.id, d]));
     const treeNode = treeMap.get(selected);
     const value = buildValue(treeMap, treeNode);


### PR DESCRIPTION
This PR fixes an issue in JadeReferenceTreeSelect where reference updates were being skipped when selecting the same value, particularly affecting cross-application node copying scenarios.

Problem
Previously, when:
1. Copying nodes between applications
2. Selecting the same reference value again
    The component would skip updates if selected === reference.referenceId, leading to:
- Stale referenceKey and value values
- Broken references in cross-application copies

Solution
Key changes:

1. Removed duplicate selection check that prevented updates
2. Now always triggers onReferencedKeyChange on selection
3. Ensures referenceKey and value stay synchronized