### PR TITLE
[fel] Add close support in McpClient and release resources properly

### DIFF
--- a/framework/fel/java/plugins/tool-mcp-test/src/main/java/modelengine/fel/tool/mcp/test/TestController.java
+++ b/framework/fel/java/plugins/tool-mcp-test/src/main/java/modelengine/fel/tool/mcp/test/TestController.java
@@ -16,6 +16,7 @@ import modelengine.fit.http.annotation.RequestMapping;
 import modelengine.fit.http.annotation.RequestQuery;
 import modelengine.fitframework.annotation.Component;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -53,6 +54,22 @@ public class TestController {
         this.client = this.mcpClientFactory.create(baseUri, sseEndpoint);
         this.client.initialize();
         return "Initialized";
+    }
+
+    /**
+     * Closes the MCP client and releases any resources associated with it.
+     * This method ensures that the MCP client is properly closed and resources are released.
+     *
+     * @return A string indicating that the close operation was successful.
+     */
+    @PostMapping(path = "/close")
+    public String close() {
+        try {
+            this.client.close();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to close.", e);
+        }
+        return "Closed";
     }
 
     /**

--- a/framework/fel/java/services/tool-mcp-client-service/src/main/java/modelengine/fel/tool/mcp/client/McpClient.java
+++ b/framework/fel/java/services/tool-mcp-client-service/src/main/java/modelengine/fel/tool/mcp/client/McpClient.java
@@ -8,6 +8,7 @@ package modelengine.fel.tool.mcp.client;
 
 import modelengine.fel.tool.mcp.entity.Tool;
 
+import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
 
@@ -20,7 +21,7 @@ import java.util.Map;
  * @author 季聿阶
  * @since 2025-05-21
  */
-public interface McpClient {
+public interface McpClient extends Closeable {
     /**
      * Initializes the MCP Client.
      */


### PR DESCRIPTION
- Added Closeable interface to McpClient to support proper resource cleanup.
- Implemented close() method in DefaultMcpClient to:
   - Cancel SSE subscription.
   - Shutdown ping scheduler gracefully.
   - Log client closure with context.
- Added /close endpoint in TestController for testing purposes to trigger client shutdown via HTTP.

This change ensures that the MCP client releases all held resources when no longer needed, improving reliability and preventing leaks.