### PR TITLE
[fel] Add configurable ping interval

### DIFF
--- a/framework/fel/java/plugins/tool-mcp-client/src/main/java/modelengine/fel/tool/mcp/client/support/DefaultMcpClientFactory.java
+++ b/framework/fel/java/plugins/tool-mcp-client/src/main/java/modelengine/fel/tool/mcp/client/support/DefaultMcpClientFactory.java
@@ -6,12 +6,15 @@
 
 package modelengine.fel.tool.mcp.client.support;
 
+import static modelengine.fitframework.inspection.Validation.notNull;
+
 import modelengine.fel.tool.mcp.client.McpClient;
 import modelengine.fel.tool.mcp.client.McpClientFactory;
 import modelengine.fit.http.client.HttpClassicClient;
 import modelengine.fit.http.client.HttpClassicClientFactory;
 import modelengine.fitframework.annotation.Component;
 import modelengine.fitframework.annotation.Fit;
+import modelengine.fitframework.annotation.Value;
 import modelengine.fitframework.serialization.ObjectSerializer;
 
 /**
@@ -26,25 +29,29 @@ import modelengine.fitframework.serialization.ObjectSerializer;
 public class DefaultMcpClientFactory implements McpClientFactory {
     private final HttpClassicClient client;
     private final ObjectSerializer jsonSerializer;
+    private final long pingInterval;
 
     /**
      * Constructs a new instance of the DefaultMcpClientFactory.
      *
      * @param clientFactory The factory used to create the HTTP client.
      * @param jsonSerializer The JSON serializer used for serialization and deserialization.
+     * @param pingInterval The interval between ping requests. Units: milliseconds.
      */
     public DefaultMcpClientFactory(HttpClassicClientFactory clientFactory,
-            @Fit(alias = "json") ObjectSerializer jsonSerializer) {
+            @Fit(alias = "json") ObjectSerializer jsonSerializer,
+            @Value("${mcp.client.ping-interval}") long pingInterval) {
         this.client = clientFactory.create(HttpClassicClientFactory.Config.builder()
                 .connectTimeout(30_000)
                 .socketTimeout(60_000)
                 .connectionRequestTimeout(60_000)
                 .build());
-        this.jsonSerializer = jsonSerializer;
+        this.jsonSerializer = notNull(jsonSerializer, "The json serializer cannot be null.");
+        this.pingInterval = pingInterval;
     }
 
     @Override
     public McpClient create(String baseUri, String sseEndpoint) {
-        return new DefaultMcpClient(this.jsonSerializer, this.client, baseUri, sseEndpoint);
+        return new DefaultMcpClient(this.jsonSerializer, this.client, baseUri, sseEndpoint, this.pingInterval);
     }
 }

--- a/framework/fel/java/plugins/tool-mcp-client/src/main/resources/application.yml
+++ b/framework/fel/java/plugins/tool-mcp-client/src/main/resources/application.yml
@@ -2,3 +2,7 @@ fit:
   beans:
     packages:
     - 'modelengine.fel.tool.mcp.client.support'
+
+mcp:
+  client:
+    ping-interval: 15000


### PR DESCRIPTION
- Introduced configurable ping interval via constructor and configuration (application.yml) with a fallback default value (15,000 ms).
- Moved ping scheduler creation to after initialization to ensure valid session state before sending pings.
- Added parameter validation in DefaultMcpClient constructor using notNull and notBlank checks for better failure visibility.
- Propagated ping interval configuration through DefaultMcpClientFactory using @Value injection.
- Improved testability and lifecycle management by decoupling scheduler setup from constructor logic.

This change increases flexibility and robustness of the MCP client, especially in different deployment and test environments.