### PR TITLE
[fit] enhance JacksonObjectSerializer with debug mode support

### DIFF
--- a/framework/fel/java/fel-community/model-openai/src/test/java/modelengine/fel/community/model/openai/entity/chat/OpenAiChatEntityTest.java
+++ b/framework/fel/java/fel-community/model-openai/src/test/java/modelengine/fel/community/model/openai/entity/chat/OpenAiChatEntityTest.java
@@ -38,7 +38,7 @@ import java.util.Optional;
  */
 @DisplayName("测试 openai 聊天请求相关数据结构序列化与反序列化")
 public class OpenAiChatEntityTest {
-    private static final ObjectSerializer SERIALIZER = new JacksonObjectSerializer(null, null, null);
+    private static final ObjectSerializer SERIALIZER = new JacksonObjectSerializer(null, null, null, true);
 
     @Nested
     class ChatMessageTest {

--- a/framework/fel/java/fel-community/model-openai/src/test/java/modelengine/fel/community/model/openai/entity/embed/OpenAiEmbedEntityTest.java
+++ b/framework/fel/java/fel-community/model-openai/src/test/java/modelengine/fel/community/model/openai/entity/embed/OpenAiEmbedEntityTest.java
@@ -25,7 +25,7 @@ import java.util.Collections;
  */
 @DisplayName("测试 openai 嵌入请求相关数据结构序列化与反序列化")
 public class OpenAiEmbedEntityTest {
-    private static final ObjectSerializer SERIALIZER = new JacksonObjectSerializer(null, null, null);
+    private static final ObjectSerializer SERIALIZER = new JacksonObjectSerializer(null, null, null, true);
 
     @Test
     @DisplayName("测试序列化嵌入请求成功")

--- a/framework/fel/java/fel-core/src/test/java/modelengine/fel/core/format/json/JsonOutputParserTest.java
+++ b/framework/fel/java/fel-core/src/test/java/modelengine/fel/core/format/json/JsonOutputParserTest.java
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
  */
 @DisplayName(("测试 JsonOutputParser"))
 public class JsonOutputParserTest {
-    private static final ObjectSerializer TEST_SERIALIZER = new JacksonObjectSerializer(null, null, null);
+    private static final ObjectSerializer TEST_SERIALIZER = new JacksonObjectSerializer(null, null, null, true);
 
     static class Joke {
         @Property(description = "question to set up a joke")

--- a/framework/fel/java/fel-core/src/test/java/modelengine/fel/core/source/support/JsonFileSourceTest.java
+++ b/framework/fel/java/fel-core/src/test/java/modelengine/fel/core/source/support/JsonFileSourceTest.java
@@ -33,7 +33,7 @@ public class JsonFileSourceTest {
     @Test
     @DisplayName("测试读取 json 文件成功，结果符合预期")
     void giveExistFileThenReturnOk() {
-        ObjectSerializer serializer = new JacksonObjectSerializer(null, null, null);
+        ObjectSerializer serializer = new JacksonObjectSerializer(null, null, null, true);
         Source<File> fileSource = new JsonFileSource(serializer, StringTemplate.create("{{instruction}}\n{{output}}"));
         URL url = this.getClass().getClassLoader().getResource("test.json");
         File file = FileUtils.file(url);

--- a/framework/fel/java/fel-core/src/test/java/modelengine/fel/core/vectorstore/support/MemoryVectorStoreTest.java
+++ b/framework/fel/java/fel-core/src/test/java/modelengine/fel/core/vectorstore/support/MemoryVectorStoreTest.java
@@ -47,7 +47,7 @@ public class MemoryVectorStoreTest {
     @Test
     @DisplayName("插入文档后，持久化后重新加载成功")
     void shouldOkWhenPersistThenLoad() throws IOException {
-        ObjectSerializer serializer = new JacksonObjectSerializer(null, null, null);
+        ObjectSerializer serializer = new JacksonObjectSerializer(null, null, null, true);
 
         MemoryVectorStore vectorStore = new MemoryVectorStore(new DefaultDocumentEmbedModel(new EmbedModelStub(),
                 EmbedOption.custom().build()));

--- a/framework/fel/java/maven-plugins/tool-maven-plugin/src/main/java/modelengine/fel/maven/complie/plugin/UrlClassLoaderInitializer.java
+++ b/framework/fel/java/maven-plugins/tool-maven-plugin/src/main/java/modelengine/fel/maven/complie/plugin/UrlClassLoaderInitializer.java
@@ -74,12 +74,9 @@ public class UrlClassLoaderInitializer {
             return;
         }
         File jsonFile = Paths.get(outputDirectory, ToolSchema.TOOL_MANIFEST).toFile();
-        JacksonObjectSerializer serializer = new JacksonObjectSerializer(
-                DEFAULT_DATE_TIME_FORMAT,
-                DEFAULT_DATE_FORMAT,
-                "Asia/Shanghai"
-        );
-        ObjectMapper objectMapper = serializer.getMapper().copy();
+        JacksonObjectSerializer serializer =
+                new JacksonObjectSerializer(DEFAULT_DATE_TIME_FORMAT, DEFAULT_DATE_FORMAT, "Asia/Shanghai", false);
+        ObjectMapper objectMapper = serializer.mapper().copy();
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         objectMapper.writerWithDefaultPrettyPrinter().writeValue(jsonFile, toolJsonEntity);
         log.info("Write tool json successfully. [file={}]", jsonFile.getName());

--- a/framework/fel/java/plugins/tool-discoverer/src/test/java/modelengine/fel/tool/support/DefaultToolDiscovererTest.java
+++ b/framework/fel/java/plugins/tool-discoverer/src/test/java/modelengine/fel/tool/support/DefaultToolDiscovererTest.java
@@ -66,7 +66,7 @@ public class DefaultToolDiscovererTest {
     @DisplayName("测试自动装载工具")
     void shouldOkWhenInstallTools() {
         doNothing().when(this.toolRepository).addTool(any());
-        ObjectSerializer serializer = new JacksonObjectSerializer(null, null, null);
+        ObjectSerializer serializer = new JacksonObjectSerializer(null, null, null, true);
         DefaultToolDiscoverer toolDiscoverer = new DefaultToolDiscoverer(this.toolRepository, serializer, 64);
         toolDiscoverer.onPluginStarted(this.plugin);
         verify(this.toolRepository, times(1)).addTool(argThat(tool -> tool.name().equals("get_delivery_date")));
@@ -76,7 +76,7 @@ public class DefaultToolDiscovererTest {
     @DisplayName("测试自动卸载工具")
     void shouldOkWhenUninstallTools() {
         doNothing().when(this.toolRepository).deleteTool(any(), any());
-        ObjectSerializer serializer = new JacksonObjectSerializer(null, null, null);
+        ObjectSerializer serializer = new JacksonObjectSerializer(null, null, null, true);
         DefaultToolDiscoverer toolDiscoverer = new DefaultToolDiscoverer(this.toolRepository, serializer, 64);
         toolDiscoverer.onPluginStopping(this.plugin);
         verify(this.toolRepository, times(1)).deleteTool(argThat(group -> true),

--- a/framework/fel/java/plugins/tool-executor/src/test/java/modelengine/fel/tool/support/DefaultToolExecutorTest.java
+++ b/framework/fel/java/plugins/tool-executor/src/test/java/modelengine/fel/tool/support/DefaultToolExecutorTest.java
@@ -53,7 +53,7 @@ public class DefaultToolExecutorTest {
     private ToolRepository toolRepository;
     private ToolFactoryRepository toolFactoryRepository;
     private ToolFactory toolFactory;
-    private final ObjectSerializer serializer = new JacksonObjectSerializer(null, null, null);
+    private final ObjectSerializer serializer = new JacksonObjectSerializer(null, null, null, true);
 
     @BeforeEach
     void setUp() {

--- a/framework/fel/java/services/tool-service/src/test/java/modelengine/fel/tool/support/FitToolTest.java
+++ b/framework/fel/java/services/tool-service/src/test/java/modelengine/fel/tool/support/FitToolTest.java
@@ -56,7 +56,7 @@ public class FitToolTest {
                     }
                     throw new IllegalStateException("Error");
                 });
-        ObjectSerializer serializer = new JacksonObjectSerializer(null, null, null);
+        ObjectSerializer serializer = new JacksonObjectSerializer(null, null, null, true);
         List<ToolEntity> toolEntities =
                 serializer.<Map<String, List<ToolEntity>>>deserialize(IoUtils.content(this.getClass().getClassLoader(),
                         ToolSchema.TOOL_MANIFEST), TypeUtils.parameterized(Map.class, new Type[] {

--- a/framework/fel/java/services/tool-service/src/test/java/modelengine/fel/tool/support/HttpToolTest.java
+++ b/framework/fel/java/services/tool-service/src/test/java/modelengine/fel/tool/support/HttpToolTest.java
@@ -113,7 +113,7 @@ public class HttpToolTest {
     }
 
     private static Tool createTool(Tool.Info info) {
-        ObjectSerializer jsonSerializer = new JacksonObjectSerializer(null, null, null);
+        ObjectSerializer jsonSerializer = new JacksonObjectSerializer(null, null, null, true);
         Map<String, ObjectSerializer> serializers =
                 MapBuilder.<String, ObjectSerializer>get().put("json", jsonSerializer).build();
         ValueFetcher valueFetcher = new FastJsonValueHandler();

--- a/framework/fel/java/services/tool-service/src/test/java/modelengine/fel/tool/support/MethodToolMetadataTest.java
+++ b/framework/fel/java/services/tool-service/src/test/java/modelengine/fel/tool/support/MethodToolMetadataTest.java
@@ -58,7 +58,7 @@ public class MethodToolMetadataTest {
 
     MethodToolMetadataTest() throws NoSuchMethodException {
         this.testMethod = TestInterface.class.getDeclaredMethod("testMethod", String.class);
-        this.serializer = new JacksonObjectSerializer(null, null, null);
+        this.serializer = new JacksonObjectSerializer(null, null, null, true);
     }
 
     @BeforeEach

--- a/framework/fel/java/services/tool-service/src/test/java/modelengine/fel/tool/support/SchemaToolMetadataTest.java
+++ b/framework/fel/java/services/tool-service/src/test/java/modelengine/fel/tool/support/SchemaToolMetadataTest.java
@@ -59,7 +59,7 @@ public class SchemaToolMetadataTest {
     private Tool tool;
     private Tool.Metadata toolMetadata;
 
-    private final ObjectSerializer jsonSerializer = new JacksonObjectSerializer(null, null, null);
+    private final ObjectSerializer jsonSerializer = new JacksonObjectSerializer(null, null, null, true);
 
     @BeforeEach
     void setup() {
@@ -82,7 +82,7 @@ public class SchemaToolMetadataTest {
         this.toolSchema = this.buildSchema();
         this.definitionSchema = this.buildDefinitionSchema();
         this.toolMetadata = Tool.Metadata.fromSchema(DEFINITION_GROUP_NAME, this.definitionSchema);
-        ObjectSerializer serializer = new JacksonObjectSerializer(null, null, null);
+        ObjectSerializer serializer = new JacksonObjectSerializer(null, null, null, true);
         FitToolFactory fitToolFactory = new FitToolFactory(client, serializer);
         this.tool = fitToolFactory.create(this.buildInfo(), this.toolMetadata);
     }

--- a/framework/fel/java/services/tool-service/src/test/java/modelengine/fel/tool/support/http/HttpClientTest.java
+++ b/framework/fel/java/services/tool-service/src/test/java/modelengine/fel/tool/support/http/HttpClientTest.java
@@ -189,7 +189,7 @@ public class HttpClientTest {
     }
 
     private HttpClassicClient createHttpClient() {
-        ObjectSerializer jsonSerializer = new JacksonObjectSerializer(null, null, null);
+        ObjectSerializer jsonSerializer = new JacksonObjectSerializer(null, null, null, true);
         Map<String, ObjectSerializer> serializers =
                 MapBuilder.<String, ObjectSerializer>get().put("json", jsonSerializer).build();
         ValueFetcher valueFetcher = new FastJsonValueHandler();

--- a/framework/fit/java/fit-builtin/plugins/fit-message-serializer-json-jackson/src/main/java/modelengine/fit/serialization/json/jackson/JacksonMessageSerializer.java
+++ b/framework/fit/java/fit-builtin/plugins/fit-message-serializer-json-jackson/src/main/java/modelengine/fit/serialization/json/jackson/JacksonMessageSerializer.java
@@ -50,7 +50,7 @@ public class JacksonMessageSerializer implements MessageSerializer {
     public JacksonMessageSerializer(@Fit(alias = "jackson") ObjectSerializer serializer, Config config) {
         this.serializer = notNull(serializer, "The Jackson serializer cannot be null.");
         JacksonObjectSerializer jacksonObjectSerializer = cast(this.serializer);
-        this.mapper = jacksonObjectSerializer.getMapper();
+        this.mapper = jacksonObjectSerializer.mapper();
         this.config = notNull(config, "The message serializer config cannot be null.");
     }
 

--- a/framework/fit/java/fit-builtin/plugins/fit-message-serializer-json-jackson/src/test/java/modelengine/fit/serialization/json/jackson/JacksonMessageSerializerTest.java
+++ b/framework/fit/java/fit-builtin/plugins/fit-message-serializer-json-jackson/src/test/java/modelengine/fit/serialization/json/jackson/JacksonMessageSerializerTest.java
@@ -37,15 +37,14 @@ import java.util.Properties;
  */
 @DisplayName("测试 JacksonMessageSerializer")
 public class JacksonMessageSerializerTest {
+    private final Properties properties = new Properties();
+    private final Config config = new PropertiesConfig("test", properties);
     private JacksonMessageSerializer messageSerializer;
-    private Properties properties = new Properties();
-    private Config config = new PropertiesConfig("test", properties);
 
     @BeforeEach
     void setup() {
-        this.messageSerializer = new JacksonMessageSerializer(
-                new JacksonObjectSerializer(null, null, null),
-                this.config);
+        this.messageSerializer =
+                new JacksonMessageSerializer(new JacksonObjectSerializer(null, null, null, true), this.config);
     }
 
     @Test

--- a/framework/fit/java/fit-builtin/plugins/fit-message-serializer-json-jackson/src/test/java/modelengine/fit/serialization/json/jackson/JacksonObjectSerializerTest.java
+++ b/framework/fit/java/fit-builtin/plugins/fit-message-serializer-json-jackson/src/test/java/modelengine/fit/serialization/json/jackson/JacksonObjectSerializerTest.java
@@ -7,6 +7,7 @@
 package modelengine.fit.serialization.json.jackson;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
 import modelengine.fit.serialization.test.enums.Gender;
 import modelengine.fit.serialization.test.person.Person;
@@ -16,6 +17,7 @@ import modelengine.fit.serialization.test.person.PersonGender;
 import modelengine.fit.serialization.test.person.PersonName;
 import modelengine.fit.serialization.test.person.PersonTransient;
 import modelengine.fitframework.serialization.ObjectSerializer;
+import modelengine.fitframework.serialization.SerializationException;
 import modelengine.fitframework.util.MapBuilder;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -52,7 +54,7 @@ public class JacksonObjectSerializerTest {
 
     @BeforeEach
     void setup() {
-        this.jsonSerializer = new JacksonObjectSerializer(null, null, "America/New_York");
+        this.jsonSerializer = new JacksonObjectSerializer(null, null, "America/New_York", true);
     }
 
     @AfterEach
@@ -183,6 +185,17 @@ public class JacksonObjectSerializerTest {
                     JacksonObjectSerializerTest.this.charset,
                     ZonedDateTime.class);
             assertThat(actual).isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("当输入错误的 Json 数据时，返回合适的错误信息")
+        void givenWrongJsonThenReturnErrorMessage() {
+            InputStream in = new ByteArrayInputStream("{\"Hello\"}".getBytes());
+            SerializationException cause = catchThrowableOfType(SerializationException.class,
+                    () -> JacksonObjectSerializerTest.this.jsonSerializer.deserialize(in,
+                            JacksonObjectSerializerTest.this.charset,
+                            String.class));
+            assertThat(cause).hasMessage("Failed to deserialize by Jackson. [content={\"Hello\"}]");
         }
 
         private InputStream constructInputStream(Object obj) {

--- a/framework/fit/java/fit-builtin/plugins/fit-message-serializer-json-jackson/src/test/java/modelengine/fit/serialization/json/jackson/MessageSerializerGenericableTest.java
+++ b/framework/fit/java/fit-builtin/plugins/fit-message-serializer-json-jackson/src/test/java/modelengine/fit/serialization/json/jackson/MessageSerializerGenericableTest.java
@@ -34,14 +34,14 @@ import java.util.stream.Stream;
  */
 @DisplayName("测试 MessageSerializer 的基本测试用例")
 public class MessageSerializerGenericableTest {
-    private Properties properties = new Properties();
-    private Config config = new PropertiesConfig("test", properties);
+    private final Properties properties = new Properties();
+    private final Config config = new PropertiesConfig("test", properties);
 
     private final MessageSerializerTest test =
             new MessageSerializerTest(() -> new JacksonMessageSerializer(new JacksonObjectSerializer(null,
                     null,
-                    null),
-                    this.config));
+                    null,
+                    true), this.config));
 
     @BeforeEach
     void setup() {

--- a/framework/fit/java/fit-test/fit-test-framework/src/main/java/modelengine/fitframework/test/domain/mvc/HttpClientFactory.java
+++ b/framework/fit/java/fit-test/fit-test-framework/src/main/java/modelengine/fitframework/test/domain/mvc/HttpClientFactory.java
@@ -33,7 +33,7 @@ public class HttpClientFactory {
      * @return 表示用于模拟测试的 {@link HttpClassicClient}。
      */
     public static HttpClassicClient create() {
-        ObjectSerializer jsonSerializer = new JacksonObjectSerializer(null, null, null);
+        ObjectSerializer jsonSerializer = new JacksonObjectSerializer(null, null, null, true);
         Map<String, ObjectSerializer> serializers =
                 MapBuilder.<String, ObjectSerializer>get().put("json", jsonSerializer).build();
         ValueFetcher valueFetcher = new FastJsonValueHandler();

--- a/framework/ohscript/src/test/java/modelengine/fit/ohscript/external/HttpTest.java
+++ b/framework/ohscript/src/test/java/modelengine/fit/ohscript/external/HttpTest.java
@@ -18,12 +18,7 @@ import modelengine.fit.ohscript.script.parser.AST;
 import modelengine.fit.ohscript.script.parser.GrammarBuilder;
 import modelengine.fit.ohscript.script.parser.ParserBuilder;
 import modelengine.fit.ohscript.util.OhScriptReader;
-import modelengine.fit.serialization.json.jackson.JacksonObjectSerializer;
-import modelengine.fit.value.fastjson.FastJsonValueHandler;
-import modelengine.fitframework.serialization.ObjectSerializer;
-import modelengine.fitframework.util.MapBuilder;
 import modelengine.fitframework.util.ObjectUtils;
-import modelengine.fitframework.value.ValueFetcher;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterEach;
@@ -59,11 +54,6 @@ public class HttpTest {
         GrammarBuilder grammarBuilder = new GrammarBuilder();
         Lexer lexer = new Lexer();
         this.parserBuilder = new ParserBuilder(grammarBuilder, lexer);
-
-        ObjectSerializer jsonSerializer = new JacksonObjectSerializer(null, null, null);
-        Map<String, ObjectSerializer> serializers =
-                MapBuilder.<String, ObjectSerializer>get().put("json", jsonSerializer).build();
-        ValueFetcher valueFetcher = new FastJsonValueHandler();
     }
 
     @AfterEach


### PR DESCRIPTION
- Added a new constructor parameter `isDebug` to enable debug mode in JacksonObjectSerializer.
- Updated deserialization error handling to include content details when debug mode is enabled.
- Adjusted test cases to accommodate the new debug mode parameter.
- Ensured consistency across all test files by updating the instantiation of JacksonObjectSerializer.