### PR TITLE
[elsa] fix(LlmNodeState): add conditional enableLog control and initialization

### DIFF
--- a/framework/elsa/fit-elsa-react/src/components/llm/LlmOutput.jsx
+++ b/framework/elsa/fit-elsa-react/src/components/llm/LlmOutput.jsx
@@ -93,11 +93,11 @@ function _LlmOutput({outputItems, enableLogData, disabled}) {
                     className="jade-panel"
                 >
                     <div className={"jade-custom-panel-content"}>
-                        <Form.Item className='jade-form-item' name={`enableLog-${enableLogData.id}`}>
+                        {enableLogData && <Form.Item className="jade-form-item" name={`enableLog-${enableLogData.id}`}>
                             <Checkbox checked={enableLogData.value} disabled={disabled}
-                                      onChange={e => dispatch({ type: 'updateLogStatus', value: e.target.checked})}><span
+                                      onChange={e => dispatch({type: 'updateLogStatus', value: e.target.checked})}><span
                               className={'jade-font-size'}>{t('pushResultToChat')}</span></Checkbox>
-                        </Form.Item>
+                        </Form.Item>}
                         <JadeObservableTree data={outputItems}/>
                         {/* 430演示大模型输出不允许用户操作，写死*/}
                         {/* <Row gutter={16}>*/}

--- a/framework/elsa/fit-elsa-react/src/flow/compatibility/compatibilityProcessors.js
+++ b/framework/elsa/fit-elsa-react/src/flow/compatibility/compatibilityProcessors.js
@@ -364,11 +364,24 @@ export const llmCompatibilityProcessor = (shapeData, graph, pageHandler) => {
       }
     };
 
+    const addEnableLog = (inputParams) => {
+      if (!inputParams.some(item => item.name === 'enableLog')) {
+        inputParams.push({
+          id: uuidv4(),
+          from: FROM_TYPE.INPUT,
+          name: 'enableLog',
+          type: DATA_TYPES.BOOLEAN,
+          value: true,
+        });
+      }
+    }
+
     const inputParams = self.shapeData.flowMeta.jober.converter.entity.inputParams;
     const outputObject = self.shapeData.flowMeta.jober.converter.entity.outputParams.find(i => i.name === 'output');
     ensureParam(inputParams, DEFAULT_MAX_MEMORY_ROUNDS);
     ensureParam(inputParams, DEFAULT_LLM_KNOWLEDGE_BASES);
     ensureParam(outputObject.value, DEFAULT_LLM_REFERENCE_OUTPUT);
+    addEnableLog(inputParams);
     if (!self.shapeData.flowMeta.jober.converter.entity.tempReference) {
       self.shapeData.flowMeta.jober.converter.entity.tempReference = {};
     }


### PR DESCRIPTION
## 🔗 相关问题 / Related Issue

<!-- 请先创建 Issue 讨论，然后在这里链接 -->
<!-- Please create an issue for discussion first, then link it here -->

**Issue 链接 / Issue Link:** [#237](https://github.com/ModelEngine-Group/app-platform/issues/237)

- [x] 我已经创建了相关 Issue 并进行了讨论 / I have created and discussed the related issue
- [ ] 这是一个微小的修改（如错别字），不需要 Issue / This is a trivial change (like typo fix) that doesn't need an issue

## 📋 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ 新功能 / New feature (non-breaking change which adds functionality)  
- [ ] 💥 破坏性变更 / Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 文档更新 / Documentation update
- [ ] 🔧 重构 / Refactoring (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 🧹 代码清理 / Code cleanup

## 📝 变更目的 / Purpose of the Change

升级到社区版本后，老应用升级后无法打开编排页面，同时问题回答会回答两遍。该变更修复上述问题，增强了对enableLog的校验，大模型节点也默认增加了enableLog这个结构体。
After upgrading to the Community Edition, legacy applications fail to load the orchestration page post-upgrade while experiencing duplicate responses in Q&A outputs. This change fixes the aforementioned issues by:

1. Enhancing validation for enableLog
2. Adding the enableLog struct to LLM nodes by default

## 📋 主要变更 / Brief Changelog

1. Conditional UI Rendering
Checkbox for enableLog now only renders when enableLogData exists
Prevents UI errors when logging functionality is unavailable
3. Core Initialization
New addEnableLog() method ensures enableLog parameter exists
Defaults to true for new configurations
Seamlessly integrates with existing parameter handling
4. Enhanced Reliability
Checks for existing enableLog before initialization
Follows established patterns from other parameter ensure methods
Preserves all existing process() workflow functionality

## 🧪 验证变更 / Verifying this Change

### 测试步骤 / Test Steps

1. Create an application on the older version
2. Upgrade the system version
3. Open the application in the upgraded system
5. The workflow page opens normally, and the output of the large model node during runtime will be printed to the chat page

### 测试覆盖 / Test Coverage

- [ ] 我已经添加了单元测试 / I have added unit tests
- [ ] 所有现有测试都通过 / All existing tests pass
- [x] 我已经进行了手动测试 / I have performed manual testing

## 📸 截图 / Screenshots

![image](https://github.com/user-attachments/assets/35d1158f-edb7-4eaa-aa0d-26623a81e668)

## ✅ 贡献者检查清单 / Contributor Checklist

请确保你的 Pull Request 符合以下要求 / Please ensure your Pull Request meets the following requirements:

**基本要求 / Basic Requirements:**

- [x] 确保有 GitHub Issue 对应这个变更（微小变更如错别字除外）/ Make sure there is a Github issue filed for the change (trivial changes like typos excluded)
- [x] 你的 Pull Request 只解决一个 Issue，没有包含其他不相关的变更 / Your PR addresses just this issue, without pulling in other changes - one PR resolves one issue
- [x] PR 中的每个 commit 都有有意义的主题行和描述 / Each commit in the PR has a meaningful subject line and body

**代码质量 / Code Quality:**

- [x] 我的代码遵循项目的代码规范 / My code follows the project's coding standards
- [x] 我已经进行了自我代码审查 / I have performed a self-review of my code
- [x] 我已经为复杂的代码添加了必要的注释 / I have commented my code, particularly in hard-to-understand areas

**测试要求 / Testing Requirements:**

- [ ] 我已经编写了必要的单元测试来验证逻辑正确性 / I have written necessary unit-tests to verify the logic correction
- [ ] 当存在跨模块依赖时，我尽量使用了 mock / I have used mocks when cross-module dependencies exist
- [x] 基础检查通过：`mvn -B clean package -Dmaven.test.skip=true`，elsa README 中的编译检查 / Basic checks pass
- [ ] 单元测试通过：`mvn clean install` / Unit tests pass

**文档和兼容性 / Documentation and Compatibility:**

- [ ] 我已经更新了相应的文档 / I have made corresponding changes to the documentation
- [x] 如果有破坏性变更，我已经在 PR 描述中详细说明 / If there are breaking changes, I have documented them in detail
- [x] 我已经考虑了向后兼容性 / I have considered backward compatibility

## 📋 附加信息 / Additional Notes

---

**审查者注意事项 / Reviewer Notes:**

